### PR TITLE
Replace build script commands that don't work in macOS

### DIFF
--- a/scripts/images
+++ b/scripts/images
@@ -24,10 +24,7 @@ build_all()
         fi
 
         echo building $FULL_IMAGE
-        ROOT=.
-        if [ -e root ]; then
-            ROOT=$(readlink -f root)
-        fi
+        [ -e root ] && ROOT=$(cd root; pwd) || ROOT=$(pwd)
         docker build --build-arg TAG=$TAG --build-arg VERSION=${VERSION} --build-arg REPO=${REPO} --build-arg ARCH=${ARCH} -f $(pwd)/Dockerfile -t $FULL_IMAGE $ROOT
         cd ..
     done
@@ -56,7 +53,7 @@ copy_all()
 
         echo building $FULL_IMAGE
         ID=$(docker create $FULL_IMAGE)
-        echo $(readlink -f ${OUTPUT})
+        echo $(cd $OUTPUT; pwd)
         rm -rf output
         docker cp ${ID}:/output .
         docker rm -fv $ID

--- a/scripts/test
+++ b/scripts/test
@@ -5,6 +5,6 @@ cd $(dirname $0)/..
 
 echo Running tests
 
-PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
+PACKAGES=". $(find . -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
 
 go test -cover -tags=test ${PACKAGES}


### PR DESCRIPTION
99% of everything play nicely, but there are a couple instances where the
command has slightly different capabilities:

- `readlink` does not have a `-f` switch, nor any other way to print the full
  path of a linked file
- `find` does not have an implicit default starting point of `.`

I was concerned the build might be unhappy operating on a symlink path but, with
these changes applied, I'm able to successfully build release artifacts in both
Ubuntu and macOS.