### PR TITLE
Init scripts should wait for the right network-online

### DIFF
--- a/overlay/etc/init.d/ccapply
+++ b/overlay/etc/init.d/ccapply
@@ -1,7 +1,7 @@
 #!/sbin/openrc-run
 
 depend() {
-    after net-online
+    after network-online
     need net
 }
 

--- a/overlay/etc/init.d/cloud-config
+++ b/overlay/etc/init.d/cloud-config
@@ -1,7 +1,7 @@
 #!/sbin/openrc-run
 
 depend() {
-    after net-online
+    after network-online
     need net
 }
 

--- a/overlay/etc/init.d/issue
+++ b/overlay/etc/init.d/issue
@@ -1,7 +1,7 @@
 #!/sbin/openrc-run
 
 depend() {
-    after net-online
+    after network-online
     need net
 }
 


### PR DESCRIPTION
The OpenRC net-online script [provides](https://github.com/OpenRC/openrc/blob/master/init.d/net-online.in#L18) `network-online`, not `net-online` (despite being in a file called `net-online`...).