### PR TITLE
Expose kernel headers by default

### DIFF
--- a/images/01-kernel-stage1/Dockerfile
+++ b/images/01-kernel-stage1/Dockerfile
@@ -33,6 +33,7 @@ RUN mkdir /usr/src/initrd && \
 
 # Generate initrd firmware and module lists
 RUN mkdir -p /output/lib && \
+    mkdir -p /output/headers && \
     cd /usr/src/initrd && \
     gzip -dc /usr/src/initrd.tmp | cpio -idmv && \
     find lib/modules -name \*.ko > /output/initrd-modules && \
@@ -43,7 +44,7 @@ RUN mkdir -p /output/lib && \
 
 # Copy output assets
 RUN cd /usr/src/root && \
-    cp -r usr/src/linux-headers* /output/headers && \
+    cp -r linux-headers*/usr/src/linux-headers* /output/headers && \
     cp -r lib/firmware /output/lib/firmware && \
     cp -r lib/modules /output/lib/modules && \
     cp boot/System.map* /output/System.map && \

--- a/images/02-rootfs/Dockerfile
+++ b/images/02-rootfs/Dockerfile
@@ -42,6 +42,7 @@ RUN chmod +s /usr/src/image/bin/sudo
 
 # Add empty dirs to bind mount
 RUN mkdir -p /usr/src/image/lib/modules
+RUN mkdir -p /usr/src/image/src
 
 # setup /usr/local
 RUN rm -rf /usr/src/image/local && \

--- a/overlay/libexec/k3os/functions
+++ b/overlay/libexec/k3os/functions
@@ -45,6 +45,8 @@ setup_kernel()
 
     mount --bind /run/k3os/kernel/lib/modules /lib/modules
     mount --bind /run/k3os/kernel/lib/firmware /lib/firmware
+    mount --bind /run/k3os/kernel/headers /usr/src
+
     umount /run/k3os/kernel
 }
 


### PR DESCRIPTION
They're there, might as well make them useable. This facilitates a DPDK build on the box for the target architecture and kernel (by mapping the hostPath as a volume.)

This change requires https://github.com/rancher/k3os-kernel/pull/2 to work properly.