### PR TITLE
Wifi fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ k3os:
   - 0.us.pool.ntp.org
   - 1.us.pool.ntp.org
   wifi:
-  - ssid: home
+  - name: home
     passphrase: mypassword
-  - ssid: nothome
+  - name: nothome
     passphrase: somethingelse
   password: rancher
   server_url: https://someserver:6443
@@ -473,16 +473,16 @@ k3os:
 
 ### `k3os.wifi`
 
-Simple wifi configuration. All that is accepted is SSID and Passphrase.  If you require more
+Simple wifi configuration. All that is accepted is Name and Passphrase.  If you require more
 complex configuration then you should use `write_files` to write a connman service config.
 
 Example:
 ```yaml
 k3os:
   wifi:
-  - ssid: home
+  - name: home
     passphrase: mypassword
-  - ssid: nothome
+  - name: nothome
     passphrase: somethingelse
 ```
 

--- a/overlay/libexec/k3os/boot
+++ b/overlay/libexec/k3os/boot
@@ -123,6 +123,16 @@ setup_hostname()
 
 }
 
+setup_wpa_supplicant()
+{
+    if [ -e /etc/conf.d/wpa_supplicant ]; then
+        return 0
+    fi
+
+    echo 'wpa_supplicant_args="-u"' > /etc/conf.d/wpa_supplicant
+    touch /etc/wpa_supplicant/wpa_supplicant.conf
+}
+
 setup_mounts()
 {
     if [ -d /.base/boot ]; then
@@ -166,6 +176,7 @@ setup_mounts
 grow_live
 setup_hostname
 setup_hosts
+setup_wpa_supplicant
 setup_shell
 setup_root
 setup_inittab

--- a/pkg/cc/funcs.go
+++ b/pkg/cc/funcs.go
@@ -190,7 +190,7 @@ func ApplyDNS(cfg *config.CloudConfig) error {
 		buf.WriteString("\n")
 	}
 
-	err := ioutil.WriteFile("/etc/connman/main.conf ", buf.Bytes(), 0644)
+	err := ioutil.WriteFile("/etc/connman/main.conf", buf.Bytes(), 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write /etc/connman/main.conf: %v", err)
 	}
@@ -230,7 +230,9 @@ func ApplyWifi(cfg *config.CloudConfig) error {
 		return ioutil.WriteFile("/var/lib/connman/cloud-config.config", buf.Bytes(), 0644)
 	}
 
-	return nil
+	cmds := []string{"rc-service wpa_supplicant start", "connmanctl enable wifi"}
+
+	return command.ExecuteCommand(cmds)
 }
 
 func ApplyDataSource(cfg *config.CloudConfig) error {

--- a/pkg/cc/funcs.go
+++ b/pkg/cc/funcs.go
@@ -218,8 +218,8 @@ func ApplyWifi(cfg *config.CloudConfig) error {
 		buf.WriteString("Passphrase=")
 		buf.WriteString(w.Passphrase)
 		buf.WriteString("\n")
-		buf.WriteString("SSID=")
-		buf.WriteString(w.SSID)
+		buf.WriteString("Name=")
+		buf.WriteString(w.Name)
 		buf.WriteString("\n")
 	}
 

--- a/pkg/cliinstall/ask.go
+++ b/pkg/cliinstall/ask.go
@@ -240,7 +240,7 @@ func AskWifi(cfg *config.CloudConfig) error {
 	}
 
 	for {
-		ssid, err := questions.Prompt("WiFi SSID: ", "")
+		name, err := questions.Prompt("WiFi Name: ", "")
 		if err != nil {
 			return err
 		}
@@ -251,7 +251,7 @@ func AskWifi(cfg *config.CloudConfig) error {
 		}
 
 		cfg.K3OS.Wifi = append(cfg.K3OS.Wifi, config.Wifi{
-			SSID:       ssid,
+			Name:       name,
 			Passphrase: pass,
 		})
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,7 +24,7 @@ type K3OS struct {
 }
 
 type Wifi struct {
-	SSID       string `json:"ssid,omitempty"`
+	Name       string `json:"name,omitempty"`
 	Passphrase string `json:"passphrase,omitempty"`
 }
 


### PR DESCRIPTION
1. Use Name instead if SSID in connman

    connman actually uses Name for "normal" wifi names and SSID is for HEX representation of an SSID that may contain special characters, etc.

    >Please note that the SSID entry is for hexadecimal encoded SSID (e.g. "SSID = 
746c735f73736964"). If your SSID does not contain any exotic character then you should use the 
Name entry instead (e.g. "Name = tls_ssid").

2. Prepare, at boot, and run wpa_supplicant, when needed, if wifi config is provided.

3. Enable wifi in connman, when needed, if wifi config is provided.