### PR TITLE
Wifi fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ k3os:
   - 0.us.pool.ntp.org
   - 1.us.pool.ntp.org
   wifi:
-  - ssid: home
+  - name: home
     passphrase: mypassword
-  - ssid: nothome
+  - name: nothome
     passphrase: somethingelse
   password: rancher
   server_url: https://someserver:6443
@@ -473,16 +473,16 @@ k3os:
 
 ### `k3os.wifi`
 
-Simple wifi configuration. All that is accepted is SSID and Passphrase.  If you require more
+Simple wifi configuration. All that is accepted is Name and Passphrase.  If you require more
 complex configuration then you should use `write_files` to write a connman service config.
 
 Example:
 ```yaml
 k3os:
   wifi:
-  - ssid: home
+  - name: home
     passphrase: mypassword
-  - ssid: nothome
+  - name: nothome
     passphrase: somethingelse
 ```
 

--- a/overlay/etc/conf.d/wpa_supplicant
+++ b/overlay/etc/conf.d/wpa_supplicant
@@ -1,0 +1,1 @@
+wpa_supplicant_args="-u"

--- a/overlay/libexec/k3os/boot
+++ b/overlay/libexec/k3os/boot
@@ -53,7 +53,7 @@ setup_services()
         ln -s /etc/init.d/$i /etc/runlevels/sysinit
     done
 
-    for i in acpid hwclock syslog bootmisc hostname sysctl modules connman dbus haveged open-vm-tools issue; do
+    for i in acpid hwclock syslog bootmisc hostname sysctl modules connman dbus haveged open-vm-tools issue wpa_supplicant; do
         ln -s /etc/init.d/$i /etc/runlevels/boot
     done
 

--- a/pkg/cc/funcs.go
+++ b/pkg/cc/funcs.go
@@ -173,6 +173,7 @@ func ApplyInstall(cfg *config.CloudConfig) error {
 
 func ApplyDNS(cfg *config.CloudConfig) error {
 	buf := &bytes.Buffer{}
+	buf.WriteString("[General]\n")
 	buf.WriteString("NetworkInterfaceBlacklist=veth\n")
 	if len(cfg.K3OS.DNSNameservers) > 0 {
 		dns := strings.Join(cfg.K3OS.DNSNameservers, ",")

--- a/pkg/cc/funcs.go
+++ b/pkg/cc/funcs.go
@@ -190,7 +190,7 @@ func ApplyDNS(cfg *config.CloudConfig) error {
 		buf.WriteString("\n")
 	}
 
-	err := ioutil.WriteFile("/etc/connman/main.conf ", buf.Bytes(), 0644)
+	err := ioutil.WriteFile("/etc/connman/main.conf", buf.Bytes(), 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write /etc/connman/main.conf: %v", err)
 	}
@@ -205,6 +205,21 @@ func ApplyWifi(cfg *config.CloudConfig) error {
 
 	buf := &bytes.Buffer{}
 
+	buf.WriteString("[WiFi]\n")
+	buf.WriteString("Enable=true\n")
+	buf.WriteString("Tethering=false\n")
+
+	if buf.Len() > 0 {
+		if err := os.MkdirAll("/var/lib/connman", 0755); err != nil {
+			return fmt.Errorf("failed to mkdir /var/lib/connman: %v", err)
+		}
+		if err := ioutil.WriteFile("/var/lib/connman/settings", buf.Bytes(), 0644); err != nil {
+			return fmt.Errorf("failed to write to /var/lib/connman/settings: %v", err)
+		}
+	}
+
+	buf = &bytes.Buffer{}
+
 	buf.WriteString("[global]\n")
 	buf.WriteString("Name=cloud-config\n")
 	buf.WriteString("Description=Services defined in the cloud-config\n")
@@ -218,15 +233,16 @@ func ApplyWifi(cfg *config.CloudConfig) error {
 		buf.WriteString("Passphrase=")
 		buf.WriteString(w.Passphrase)
 		buf.WriteString("\n")
-		buf.WriteString("SSID=")
-		buf.WriteString(w.SSID)
+		buf.WriteString("Name=")
+		buf.WriteString(w.Name)
+		buf.WriteString("\n")
+		buf.WriteString("AutoConnect=true")
+		buf.WriteString("\n")
+		buf.WriteString("Favorite=true")
 		buf.WriteString("\n")
 	}
 
 	if buf.Len() > 0 {
-		if err := os.MkdirAll("/var/lib/connman", 0755); err != nil {
-			return fmt.Errorf("failed to mkdir /var/lib/connman: %v", err)
-		}
 		return ioutil.WriteFile("/var/lib/connman/cloud-config.config", buf.Bytes(), 0644)
 	}
 

--- a/pkg/cliinstall/ask.go
+++ b/pkg/cliinstall/ask.go
@@ -240,7 +240,7 @@ func AskWifi(cfg *config.CloudConfig) error {
 	}
 
 	for {
-		ssid, err := questions.Prompt("WiFi SSID: ", "")
+		name, err := questions.Prompt("WiFi Name: ", "")
 		if err != nil {
 			return err
 		}
@@ -251,7 +251,7 @@ func AskWifi(cfg *config.CloudConfig) error {
 		}
 
 		cfg.K3OS.Wifi = append(cfg.K3OS.Wifi, config.Wifi{
-			SSID:       ssid,
+			Name:       name,
 			Passphrase: pass,
 		})
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,7 +24,7 @@ type K3OS struct {
 }
 
 type Wifi struct {
-	SSID       string `json:"ssid,omitempty"`
+	Name       string `json:"name,omitempty"`
 	Passphrase string `json:"passphrase,omitempty"`
 }
 


### PR DESCRIPTION
connman actually uses Name for "normal" wifi names and SSID is for HEX representation of an SSID that may contain special characters, etc.

Prepare and run wpa_supplicant at boot

Enable wifi in connman if we have wifi in k3os config

Auto connect to wifi

I've tried these changes out on my raspberry pi 3+ using the arm overlay installation.
It seems everything is setup correctly however I don't seem to be able to get connman to auto connect to the wifi for some reason. I can manually just run `sudo connmanctl connect wifi_....` and it will connect to the stored wifi.

I'm submitting this as draft PR in the hopes that someone else might see what's preventing the setup from auto connecting.