### PR TITLE
Update alpine to 3.10 for base image

### DIFF
--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -1,5 +1,5 @@
 ### BASE ###
-FROM alpine:3.9 as base
+FROM alpine:3.10 as base
 ARG ARCH
 RUN apk -U add \
     bash \


### PR DESCRIPTION
This is needed to get the newer `connman` which has fixes to not use gateways as ntp servers by default.

For this to have any effect, #137 should also be merged.