### PR TITLE
Maybe a typo for grub-mkrescue flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ cp /mnt/boot/grub/grub.cfg iso/boot/grub/
 
 # Edit iso/boot/grub/grub.cfg
 
-grub-mkrescue -o k3os-new.iso iso/ -V K3OS
+grub-mkrescue -o k3os-new.iso iso/ -v K3OS
 ```
 
 ### Takeover Installation


### PR DESCRIPTION
Hello,

Following your documentation, i think it has a typo error about an flag. The documentation says to use a `-V` flag while this flag is used to display the version of the executable.
Maybe the wanted flag is `v` ?

```
  grub-mkrescue --help
  -v, --verbose print verbose messages.
  -V, --version print program version
```

I just made this PR if this error is a real error.

Thank you :)