### PR TITLE
update alpine, golang, and k3s versions

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine
+FROM golang:1.12-alpine
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH

--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -1,5 +1,5 @@
 ### BASE ###
-FROM alpine:3.9 as base
+FROM alpine:3.10 as base
 ARG ARCH
 RUN apk -U add \
     bash \

--- a/images/01-k3s/Dockerfile
+++ b/images/01-k3s/Dockerfile
@@ -4,9 +4,9 @@ FROM ${REPO}/k3os-base:${TAG}
 
 ARG ARCH
 ENV ARCH ${ARCH}
-ENV VERSION v0.5.0
+ENV VERSION v0.8.1
 RUN mkdir -p /output && \
     curl -o /output/install.sh -fL https://raw.githubusercontent.com/ibuildthecloud/k3s-dev/5d5352ba1ca742199afa062ca08bf56f40b71d4b/install.sh && \
     chmod +x /output/install.sh
-RUN K3S_VERSION=${VERSION} INSTALL_K3S_SKIP_START=true INSTALL_K3S_BIN_DIR=/output /output/install.sh
+RUN INSTALL_K3S_VERSION=${VERSION} INSTALL_K3S_SKIP_START=true INSTALL_K3S_BIN_DIR=/output /output/install.sh
 RUN echo "${VERSION}" > /output/version


### PR DESCRIPTION
The k3s version has not been bumped in a long time, which is the main motivation for this. But with the recent Go HTTP2 CVEs I wanted to get that in as well. Alpine 3.10 was just a bonus to keep things fresh. I've tested the resulting artifacts in VirtualBox. 