### PR TITLE
overlay: refactor static here-docs in boot script

### DIFF
--- a/overlay/etc/inittab
+++ b/overlay/etc/inittab
@@ -1,0 +1,13 @@
+# /etc/inittab
+
+::sysinit:/sbin/openrc sysinit
+::sysinit:/sbin/openrc boot
+::wait:/sbin/openrc default
+
+# Stuff to do for the 3-finger salute
+::ctrlaltdel:/sbin/reboot
+
+# Stuff to do before rebooting
+::shutdown:/sbin/openrc shutdown
+
+# Dynamically appended getty stuff

--- a/overlay/etc/securetty
+++ b/overlay/etc/securetty
@@ -1,0 +1,1 @@
+console

--- a/overlay/libexec/k3os/boot
+++ b/overlay/libexec/k3os/boot
@@ -1,23 +1,7 @@
 #!/bin/bash
 
-setup_inittab()
+setup_ttys()
 {
-    cat > /etc/inittab << "EOF"
-# /etc/inittab
-
-::sysinit:/sbin/openrc sysinit
-::sysinit:/sbin/openrc boot
-::wait:/sbin/openrc default
-
-# Stuff to do for the 3-finger salute
-::ctrlaltdel:/sbin/reboot
-
-# Stuff to do before rebooting
-::shutdown:/sbin/openrc shutdown
-EOF
-
-    echo console > /etc/securetty
-
     for i in 1 2 3 4 5 6; do
         if [ -e /dev/tty${i} ]; then
             echo 'tty'$i'::respawn:/sbin/getty 38400 tty'$i >> /etc/inittab
@@ -168,7 +152,7 @@ setup_hostname
 setup_hosts
 setup_shell
 setup_root
-setup_inittab
+setup_ttys
 setup_sudoers
 setup_services
 ccapply --boot


### PR DESCRIPTION
This moves `/etc/inittab` and `/etc/securetty` static base files out of here-documents in the boot script (they are appended too during boot dynamically based on the tty/ttyS profile). Also renamed the `setup_inittab` function to `setup_ttys` as that is its primary concern.