### PR TITLE
update k3s install.sh to match version

### DIFF
--- a/images/01-k3s/Dockerfile
+++ b/images/01-k3s/Dockerfile
@@ -6,7 +6,7 @@ ARG ARCH
 ENV ARCH ${ARCH}
 ENV VERSION v0.8.1
 RUN mkdir -p /output && \
-    curl -o /output/install.sh -fL https://raw.githubusercontent.com/ibuildthecloud/k3s-dev/5d5352ba1ca742199afa062ca08bf56f40b71d4b/install.sh && \
+    curl -o /output/install.sh -fL https://raw.githubusercontent.com/rancher/k3s/${VERSION}/install.sh && \
     chmod +x /output/install.sh
 RUN INSTALL_K3S_VERSION=${VERSION} INSTALL_K3S_SKIP_START=true INSTALL_K3S_BIN_DIR=/output /output/install.sh
 RUN echo "${VERSION}" > /output/version


### PR DESCRIPTION
This updates the k3s install script to match the [install.sh](https://github.com/rancher/k3s/blob/master/install.sh) for the specified k3s version (aka tag).