### PR TITLE
bump kernel to 4.15.0-62.69-rancher1

### DIFF
--- a/images/01-kernel-stage1/Dockerfile
+++ b/images/01-kernel-stage1/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -y && \
 
 ARG ARCH
 ENV KVERSION=4.15.0-47-generic
-ENV URL=https://github.com/rancher/k3os-kernel/releases/download/4.15.0-47.50-rancher2
+ENV URL=https://github.com/rancher/k3os-kernel/releases/download/4.15.0-62.69-rancher1
 ENV KERNEL_XZ=${URL}/kernel-generic_${ARCH}.tar.xz
 ENV KERNEL_EXTRA_XZ=${URL}/kernel-extra-generic_${ARCH}.tar.xz
 ENV KERNEL_HEADERS_XZ=${URL}/kernel-headers-generic_${ARCH}.tar.xz

--- a/images/01-kernel-stage1/Dockerfile
+++ b/images/01-kernel-stage1/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update -y && \
     apt-get install -y kmod initramfs-tools curl rsync xz-utils
 
 ARG ARCH
-ENV KVERSION=4.15.0-47-generic
+ENV KVERSION=4.15.0-62-generic
 ENV URL=https://github.com/rancher/k3os-kernel/releases/download/4.15.0-62.69-rancher1
 ENV KERNEL_XZ=${URL}/kernel-generic_${ARCH}.tar.xz
 ENV KERNEL_EXTRA_XZ=${URL}/kernel-extra-generic_${ARCH}.tar.xz

--- a/images/01-kernel-stage1/Dockerfile
+++ b/images/01-kernel-stage1/Dockerfile
@@ -33,6 +33,7 @@ RUN mkdir /usr/src/initrd && \
 
 # Generate initrd firmware and module lists
 RUN mkdir -p /output/lib && \
+    mkdir -p /output/headers && \
     cd /usr/src/initrd && \
     gzip -dc /usr/src/initrd.tmp | cpio -idmv && \
     find lib/modules -name \*.ko > /output/initrd-modules && \
@@ -43,7 +44,7 @@ RUN mkdir -p /output/lib && \
 
 # Copy output assets
 RUN cd /usr/src/root && \
-    cp -r usr/src/linux-headers* /output/headers && \
+    cp -r linux-headers*/usr/src/linux-headers* /output/headers && \
     cp -r lib/firmware /output/lib/firmware && \
     cp -r lib/modules /output/lib/modules && \
     cp boot/System.map* /output/System.map && \

--- a/images/02-rootfs/Dockerfile
+++ b/images/02-rootfs/Dockerfile
@@ -42,6 +42,7 @@ RUN chmod +s /usr/src/image/bin/sudo
 
 # Add empty dirs to bind mount
 RUN mkdir -p /usr/src/image/lib/modules
+RUN mkdir -p /usr/src/image/src
 
 # setup /usr/local
 RUN rm -rf /usr/src/image/local && \

--- a/overlay/libexec/k3os/functions
+++ b/overlay/libexec/k3os/functions
@@ -45,6 +45,8 @@ setup_kernel()
 
     mount --bind /run/k3os/kernel/lib/modules /lib/modules
     mount --bind /run/k3os/kernel/lib/firmware /lib/firmware
+    mount --bind /run/k3os/kernel/headers /usr/src
+
     umount /run/k3os/kernel
 }
 


### PR DESCRIPTION
This bumps the kernel to [`4.15.0-62.69-rancher1`](https://github.com/rancher/k3os-kernel/releases/tag/4.15.0-62.69-rancher1) and incorporates #140 from @kraney