### PR TITLE
base: revert to alpine 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.dapper
 /.cache
 /.trash-cache
-/bin
-/dist
+/bin/
+/dist/
+/build/
 *.swp

--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -1,7 +1,8 @@
 ### BASE ###
-FROM alpine:3.10 as base
+FROM alpine:3.9 as base
 ARG ARCH
-RUN apk -U add \
+RUN apk --no-cache add \
+    $([ "$ARCH" == "amd64" ] && echo "open-vm-tools grub-bios") \
     bash \
     bash-completion \
     blkid \
@@ -37,12 +38,7 @@ RUN apk -U add \
     util-linux \
     vim \
     xz
-RUN if [ "$ARCH" == "amd64" ]; then \
-        apk add open-vm-tools grub-bios \
-    ;fi
-RUN cp /etc/apk/repositories /etc/apk/repositories.orig && \
-    echo 'http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories && \
-    echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
-    apk -U add efibootmgr && \
-    mv /etc/apk/repositories.orig /etc/apk/repositories && \
-    apk update
+RUN apk --no-cache add \
+    --repository 'http://dl-cdn.alpinelinux.org/alpine/edge/community' \
+    --repository 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' \
+    efibootmgr

--- a/images/01-k3s/Dockerfile
+++ b/images/01-k3s/Dockerfile
@@ -5,8 +5,10 @@ FROM ${REPO}/k3os-base:${TAG}
 ARG ARCH
 ENV ARCH ${ARCH}
 ENV VERSION v0.8.1
-RUN mkdir -p /output && \
-    curl -o /output/install.sh -fL https://raw.githubusercontent.com/rancher/k3s/${VERSION}/install.sh && \
-    chmod +x /output/install.sh
-RUN INSTALL_K3S_VERSION=${VERSION} INSTALL_K3S_SKIP_START=true INSTALL_K3S_BIN_DIR=/output /output/install.sh
+ADD https://raw.githubusercontent.com/rancher/k3s/${VERSION}/install.sh /output/install.sh
+ENV INSTALL_K3S_VERSION=${VERSION} \
+    INSTALL_K3S_SKIP_START=true \
+    INSTALL_K3S_BIN_DIR=/output
+RUN chmod +x /output/install.sh
+RUN /output/install.sh
 RUN echo "${VERSION}" > /output/version

--- a/images/02-rootfs/Dockerfile
+++ b/images/02-rootfs/Dockerfile
@@ -62,7 +62,7 @@ RUN rm -rf \
     cp -rf /etc/ssl/certs/ca-certificates.crt /usr/src/image/etc/ssl/certs
 
 RUN rm -rf \
-    /usr/src/image/usr/sbin/apk \
+    /usr/src/image/sbin/apk \
     /usr/src/image/usr/include \
     /usr/src/image/usr/lib/apk \
     /usr/src/image/usr/lib/pkgconfig \

--- a/overlay/etc/conf.d/k3s-service
+++ b/overlay/etc/conf.d/k3s-service
@@ -1,0 +1,3 @@
+rc_need="!net !net-online"
+rc_after="ccapply"
+rc_want="network-online"

--- a/overlay/etc/conf.d/net-online
+++ b/overlay/etc/conf.d/net-online
@@ -1,0 +1,23 @@
+# The interfaces setting controls which interfaces the net-online
+# service considers in deciding whether the network is active. The
+# default is all interfaces that support ethernet.
+#interfaces="eth0 wlan0"
+
+# The minimum_up setting controls how many interfaces the net-online
+# service expects to be "up" when deciding whether the network is active.
+# The default is the number of detected/specified interfaces.
+minimum_up=1
+
+# This setting controls whether a ping test is included in the test for
+# network connectivity after all interfaces are active.
+include_ping_test=yes
+
+# This setting is the host to attempt to ping if the above is yes.
+# The default is google.com.
+#ping_test_host=get.k3s.io
+
+# The timeout setting controls how long the net-online service waits
+# for the network to be configured.
+# The default is 120 seconds.
+# if this is set to 0, the wait is infinite.
+timeout=30

--- a/overlay/etc/init.d/ccapply
+++ b/overlay/etc/init.d/ccapply
@@ -1,8 +1,7 @@
 #!/sbin/openrc-run
 
 depend() {
-    after network-online
-    need net
+    want network-online
 }
 
 name="ccapply"

--- a/overlay/etc/init.d/cloud-config
+++ b/overlay/etc/init.d/cloud-config
@@ -1,8 +1,8 @@
 #!/sbin/openrc-run
 
 depend() {
-    after network-online
-    need net
+    want network-online
+    before ccapply
 }
 
 name="cloud-config"

--- a/overlay/etc/init.d/issue
+++ b/overlay/etc/init.d/issue
@@ -1,8 +1,7 @@
 #!/sbin/openrc-run
 
 depend() {
-    after network-online
-    need net
+    use network-online
 }
 
 name="issue"

--- a/overlay/etc/init.d/net-online
+++ b/overlay/etc/init.d/net-online
@@ -1,0 +1,76 @@
+#!/sbin/openrc-run
+# Copyright (c) 2015 The OpenRC Authors.
+# See the Authors file at the top-level directory of this distribution and
+# https://github.com/OpenRC/openrc/blob/master/AUTHORS
+#
+# This file is part of OpenRC. It is subject to the license terms in
+# the LICENSE file found in the top-level directory of this
+# distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+# This file may not be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE file.
+
+description="Delays until the network is online or a specific timeout"
+
+depend()
+{
+	after modules net
+	need sysfs
+	provide network-online
+	keyword -docker -jail -lxc -openvz -prefix -systemd-nspawn -uml -vserver
+}
+
+get_interfaces()
+{
+	local ifname iftype
+	for ifname in /sys/class/net/*; do
+		read iftype < ${ifname}/type
+		[ "$iftype" = "1" ] && printf "%s " ${ifname##*/}
+	done
+}
+
+start ()
+{
+	local carriers configured dev gateway ifcount infinite
+	local carrier operstate rc
+
+	ebegin "Checking to see if the network is online"
+	rc=0
+	interfaces=${interfaces:-$(get_interfaces)}
+	timeout=${timeout:-120}
+	[ $timeout -eq 0 ] && infinite=true || infinite=false
+	while $infinite || [ $timeout -gt 0 ]; do
+		carriers=0
+		configured=0
+		ifcount=0
+		for dev in ${interfaces}; do
+			[ -e /sys/class/net/$dev ] || continue
+			: $((ifcount += 1))
+			read carrier < /sys/class/net/$dev/carrier 2> /dev/null ||
+				carrier=
+			[ "$carrier" = 1 ] && : $((carriers += 1))
+			read operstate < /sys/class/net/$dev/operstate 2> /dev/null ||
+				operstate=
+			[ "$operstate" = up ] && : $((configured += 1))
+		done
+		[ $configured -ge ${minimum_up:-${ifcount}} ] && [ $carriers -ge 1 ] && break
+		sleep 1
+		: $((timeout -= 1))
+	done
+	! $infinite && [ $timeout -eq 0 ] && rc=1
+	include_ping_test=${include_ping_test:-${ping_default_gateway}}
+	if [ -n "${ping_default_gateway}" ]; then
+		ewarn "ping_default_gateway is deprecated, please use include_ping_test"
+	fi
+ 	if [ $rc -eq 0 ] && yesno ${include_ping_test:-no}; then
+		ping_test_host="${ping_test_host:-google.com}"
+		if [ -n "$ping_test_host" ]; then
+			while $infinite || [ $timeout -gt 0 ]; do
+				ping -c 1 $ping_test_host > /dev/null 2>&1
+				rc=$?
+				[ $rc -eq 0 ] && break
+				: $((timeout -= 1))
+			done
+		fi
+	fi
+	eend $rc "The network is offline"
+}

--- a/overlay/libexec/k3os/boot
+++ b/overlay/libexec/k3os/boot
@@ -41,7 +41,7 @@ setup_services()
         ln -s /etc/init.d/$i /etc/runlevels/boot
     done
 
-    for i in sshd k3s "local" ccapply iscsid; do
+    for i in sshd "local" ccapply iscsid; do
         ln -s /etc/init.d/$i /etc/runlevels/default
     done
 

--- a/scripts/run-qemu
+++ b/scripts/run-qemu
@@ -1,6 +1,6 @@
 #!/bin/bash
 . $(dirname $0)/version
-: ${STATEDIR:=/tmp/k3os-$TAG} # unique value per vm instance
+: ${STATEDIR:=$(dirname $0)/../build/state/k3os-$TAG} # unique value per vm instance
 
 set -e
 


### PR DESCRIPTION
Reverts to alpine 3.9 for the base build. This side-steps:
- connman segfaulting after mostly setting up the NIC
- dbus-daemon failing to start

Additionally, this includes:
- removal of the `apk` executable
- forked openrc `net-online` script that actually works
- establishes default runlevel boot order
  - (network-online) -> [cloud-config] -> ccapply -> k3s-service
with `network-online` attempted but not preventing bootup of downstream services if it fails and the optional `cloud-config` running before ccapply if present

Fixes #183
Fixes #179
Fixes #88