### PR TITLE
config: yaml numbers to json strings in maps

### DIFF
--- a/pkg/config/coerce.go
+++ b/pkg/config/coerce.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/rancher/mapper"
+	"github.com/rancher/mapper/convert"
 	"github.com/rancher/mapper/mappers"
 )
 
@@ -50,6 +51,19 @@ func NewTypeConverter(fieldType string, converter Converter) mapper.Mapper {
 		fieldType: fieldType,
 		converter: converter,
 	}
+}
+
+func NewToMap() mapper.Mapper {
+	return NewTypeConverter("map[string]", func(val interface{}) interface{} {
+		if m, ok := val.(map[string]interface{}); ok {
+			obj := make(map[string]string, len(m))
+			for k, v := range m {
+				obj[k] = convert.ToString(v)
+			}
+			return obj
+		}
+		return val
+	})
 }
 
 func NewToSlice() mapper.Mapper {

--- a/pkg/config/read.go
+++ b/pkg/config/read.go
@@ -24,6 +24,7 @@ var (
 	schemas = mapper.NewSchemas().Init(func(s *mapper.Schemas) *mapper.Schemas {
 		s.DefaultMappers = func() []mapper.Mapper {
 			return []mapper.Mapper{
+				NewToMap(),
 				NewToSlice(),
 				NewToBool(),
 				&FuzzyNames{},


### PR DESCRIPTION
This adds a mapper for cloud-config schemas to coerce a `map[string]interface{}` to `map[string]string`.

Fixes #95