### PR TITLE
Fix boot for nvme systems

### DIFF
--- a/overlay/libexec/k3os/mode-disk
+++ b/overlay/libexec/k3os/mode-disk
@@ -8,8 +8,8 @@ grow()
 {
     parted $1 resizepart $2 100%
     partprobe $1
-    e2fsck -f ${1}${2}
-    resize2fs ${1}${2}
+    e2fsck -f $3
+    resize2fs $3
 }
 
 setup_mounts()
@@ -20,12 +20,21 @@ setup_mounts()
     if [ -e $TARGET/k3os/system/growpart ]; then
         read DEV NUM < $TARGET/k3os/system/growpart
         if [ ! -e "${DEV}${NUM}" ]; then
-            DEV=$(blkid -L K3OS_STATE | sed 's![0-9][0-9]*$!!')
-            NUM=$(blkid -L K3OS_STATE | sed 's!.*[^0-9]!!')
+            # /dev/sda2 => /dev/sda2
+            # /dev/nvme0n1p2 => /dev/nvme0n1p2
+            PART=$(blkid -L K3OS_STATE)
+
+            # /dev/sda2 => /dev/sda
+            # /dev/nvme0n1p2 => /dev/nvme0n1
+            DEV=$(echo "$PART" | sed -r 's/((\d+)p)?\d+$/\2/')
+
+            # /dev/sda2 => 2
+            # /dev/nvme0n1p2 => 2
+            NUM=$(echo "$PART" | sed 's!.*[^0-9]!!')
         fi
-        if [ -e "${DEV}${NUM}" ]; then
+        if [ -e "${PART}" ]; then
             umount /run/k3os/target
-            grow $DEV $NUM || true
+            grow $DEV $NUM $PART || true
             mount -L K3OS_STATE /run/k3os/target
         fi
         rm -f $TARGET/k3os/system/growpart


### PR DESCRIPTION
This fixed install on my system at least. It seems that #104 has already been resolved (when building ISO from source I didn't get an issue during install), but it would not boot, giving me an error that it could not stat `/dev/nvme0n1p` which is not a device.