### PR TITLE
Duplicate reference to k3os.token

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,6 @@ are supported in each phase.
 | k3os.k3s_args        |        |  x   |    x    |
 | k3os.environment     |    x   |  x   |    x    |
 | k3os.taints          |        |  x   |    x    |
-| k3os.token           |        |  x   |    x    |
  
 ### Networking
 


### PR DESCRIPTION
Removed duplicate reference to k3os.token in phases table.