### PR TITLE
rootfs: fix ldd symlink

### DIFF
--- a/images/02-rootfs/Dockerfile
+++ b/images/02-rootfs/Dockerfile
@@ -31,11 +31,10 @@ RUN cd /usr/src/image && \
    ;done && \
    rmdir usr
 
-# Fix coreutils links
-RUN cd /usr/src/image/bin && \
-    mv coreutils coreutils.save && \
-    find -xtype l -exec rm {} \; -exec ln -s coreutils {} \; && \
-    mv coreutils.save coreutils
+# Fix ldd and coreutils links
+RUN cd /usr/src/image/bin \
+ && ln -sf $(realpath $(which ldd)) ldd \
+ && find -xtype l -ilname ../usr/bin/coreutils -exec ln -sf coreutils {} \;
 
 # Fix sudo
 RUN chmod +s /usr/src/image/bin/sudo


### PR DESCRIPTION
This addresses #194 by correctly adjusting the ldd and coreutils symlinks.