### PR TITLE
package: fix the packer aws template for arm64

### DIFF
--- a/package/packer/aws/template-arm64.json
+++ b/package/packer/aws/template-arm64.json
@@ -4,7 +4,7 @@
     "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "region": "us-east-1",
     "k3os_version": "v0.3.0",
-    "iso_url": "https://github.com/rancher/k3os/releases/download/v0.3.0/k3os-amd64.iso"
+    "iso_url": "https://github.com/rancher/k3os/releases/download/v0.3.0/k3os-arm64.iso"
   },
   "builders": [{
     "type": "amazon-ebs",


### PR DESCRIPTION
Pull in the ARM64 ISO and not the AMD64.