### PR TITLE
Added logging to commands

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -3,6 +3,7 @@ package command
 import (
 	"bytes"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 func ExecuteCommand(commands []string) error {
 	for _, cmd := range commands {
+		logrus.Debugf("running cmd `%s`", cmd)
 		c := exec.Command("sh", "-c", cmd)
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -3,10 +3,11 @@ package command
 import (
 	"bytes"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 func ExecuteCommand(commands []string) error {


### PR DESCRIPTION
I was running into issues around using `boot_cmd` in a kernel parameter (subsequent PR to follow to fix that). I added this to give me a bit more information during the boot process & thought it might be useful!