### PR TITLE
fixes #216 - Parse quoted kernel arguments

### DIFF
--- a/pkg/config/read.go
+++ b/pkg/config/read.go
@@ -152,7 +152,7 @@ func readFile(path string) (map[string]interface{}, error) {
 
 func readCmdline() (map[string]interface{}, error) {
 	//supporting regex https://regexr.com/4mq0s
-	parser, err := regexp.Compile(`([^\s]+=(\"[^\"]*\")|([^\s]+))`)
+	parser, err := regexp.Compile(`(\"[^\"]+\")|([^\s]+=(\"[^\"]+\")|([^\s]+))`)
 	if err != nil {
 		return nil, nil
 	}
@@ -171,7 +171,7 @@ func readCmdline() (map[string]interface{}, error) {
 		if len(parts) > 1 {
 			value = strings.Trim(parts[1], `"`)
 		}
-		keys := strings.Split(parts[0], ".")
+		keys := strings.Split(strings.Trim(parts[0], `"`), ".")
 		existing, ok := values.GetValue(data, keys...)
 		if ok {
 			switch v := existing.(type) {

--- a/pkg/config/read.go
+++ b/pkg/config/read.go
@@ -152,7 +152,7 @@ func readFile(path string) (map[string]interface{}, error) {
 
 func readCmdline() (map[string]interface{}, error) {
 	//supporting regex https://regexr.com/4mq0s
-	parser, err := regexp.Compile(`([^\s]+=(\".*\")|([^\s]+))`)
+	parser, err := regexp.Compile(`([^\s]+=(\"[^\"]*\")|([^\s]+))`)
 	if err != nil {
 		return nil, nil
 	}

--- a/pkg/config/read.go
+++ b/pkg/config/read.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -150,6 +151,12 @@ func readFile(path string) (map[string]interface{}, error) {
 }
 
 func readCmdline() (map[string]interface{}, error) {
+	//supporting regex https://regexr.com/4mq0s
+	parser, err := regexp.Compile(`([^\s]+=(\".*\")|([^\s]+))`)
+	if err != nil {
+		return nil, nil
+	}
+
 	bytes, err := ioutil.ReadFile("/proc/cmdline")
 	if os.IsNotExist(err) {
 		return nil, nil
@@ -158,11 +165,11 @@ func readCmdline() (map[string]interface{}, error) {
 	}
 
 	data := map[string]interface{}{}
-	for _, item := range strings.Fields(string(bytes)) {
+	for _, item := range parser.FindAllString(string(bytes), -1) {
 		parts := strings.SplitN(item, "=", 2)
 		value := "true"
 		if len(parts) > 1 {
-			value = parts[1]
+			value = strings.Trim(parts[1], `"`)
 		}
 		keys := strings.Split(parts[0], ".")
 		existing, ok := values.GetValue(data, keys...)


### PR DESCRIPTION
As outlined in #216 I noticed an issue with spaces in quoted kernel arguments. I found this regex to be a nice way to parse the kernel arguments.

I choose regex because kernel arguments should be fairly bounded & this regex defines a nice lexicon for what is possible in kernel arguments. I am by no means a regex expert so it may be good to add some testing. I didn't see a good pattern for how to adjust the code to make it more testable, but I'm happy to make changes requested!