### PR TITLE
Fix mount options in upgrade scripts

### DIFF
--- a/overlay/sbin/k3os-upgrade-kernel
+++ b/overlay/sbin/k3os-upgrade-kernel
@@ -35,7 +35,7 @@ KERNEL_VERSION=$(curl -sL https://github.com/rancher/k3os/releases/${K3OS_VERSIO
 echo "Upgrading k3os kernel to ${KERNEL_VERSION}"
 
 cd /k3os/system/
-mount -o remount rw .
+mount -o remount,rw .
 cd kernel
 mkdir -p ${KERNEL_VERSION}
 cd ${KERNEL_VERSION}

--- a/overlay/sbin/k3os-upgrade-rootfs
+++ b/overlay/sbin/k3os-upgrade-rootfs
@@ -33,7 +33,7 @@ echo "Upgrading k3os to ${K3OS_VERSION}"
 K3OS_ROOTFS_URL="https://github.com/rancher/k3os/releases/download/${K3OS_VERSION}/k3os-rootfs-${ARCH}.tar.gz"
 
 cd /k3os/system/
-mount -o remount rw .
+mount -o remount,rw .
 curl -fsSL "${K3OS_ROOTFS_URL}" | tar xz --strip-components=3
 sync
 


### PR DESCRIPTION
mount's options argument takes a comma separated list of options according to the man pages.

/cc @bhale