### PR TITLE
iso: stub out custom config.yaml

### DIFF
--- a/images/06-iso/Dockerfile
+++ b/images/06-iso/Dockerfile
@@ -27,11 +27,11 @@ RUN cd /usr/src/kernel && \
     mkdir -p /usr/src/iso/k3os/system/kernel/$(cat version) && \
     cp initrd kernel.squashfs /usr/src/iso/k3os/system/kernel/$(cat version) && \
     ln -s $(cat version) /usr/src/iso/k3os/system/kernel/current
-
 COPY --from=tar /output/userspace.tar /usr/src/tars/
 RUN tar xvf /usr/src/tars/userspace.tar --strip-components=1 -C /usr/src/iso
 
 COPY wrapper /usr/bin/
+COPY config.yaml /usr/src/iso/k3os/system/
 RUN mkdir -p /output && \
     cd /usr/src/iso && \
     grub-mkrescue --xorriso=/usr/bin/wrapper -o /output/k3os.iso . -V K3OS && \

--- a/images/06-iso/config.yaml
+++ b/images/06-iso/config.yaml
@@ -1,0 +1,3 @@
+# See https://github.com/rancher/k3os/blob/master/README.md#configuration
+# and https://github.com/rancher/k3os/blob/master/README.md#remastering-iso
+# This file is a placeholder for custom configuration when building a custom ISO image.


### PR DESCRIPTION
This demonstrates where to please custom config.yaml into the project tree when there is a need to create a custom ISO image from source.

Addresses #238 