### PR TITLE
ccapply: avoid aggressive fail when reading ssh keys from github

### DIFF
--- a/overlay/etc/conf.d/net-online
+++ b/overlay/etc/conf.d/net-online
@@ -10,7 +10,7 @@ minimum_up=1
 
 # This setting controls whether a ping test is included in the test for
 # network connectivity after all interfaces are active.
-include_ping_test=yes
+#include_ping_test=yes
 
 # This setting is the host to attempt to ping if the above is yes.
 # The default is google.com.

--- a/scripts/run-qemu
+++ b/scripts/run-qemu
@@ -25,5 +25,8 @@ exec $QEMU_SYSTEM \
     -nographic \
     -serial mon:stdio \
     -rtc base=utc,clock=rt \
+    -kernel $(dirname $0)/../dist/artifacts/k3os-vmlinuz-$ARCH \
+    -initrd $(dirname $0)/../dist/artifacts/k3os-initrd-$ARCH \
     -cdrom $(dirname $0)/../dist/artifacts/k3os-$ARCH.iso \
-    -drive if=virtio,file=$STATEDIR/hd.img
+    -drive if=virtio,file=$STATEDIR/hd.img \
+    -append "printk.devkmsg=on console=ttyS0 loglevel=4 ${@}"


### PR DESCRIPTION
ssh.SetAuthorizedKeys() will now retry up to 10 times, sleeping 1 second in between,
to read public keys from github (if any are specified). This moots the need for the
ping-test in net-online and addresses #224 while maintaining a best-effort attempt to
read github public keys.

`net-online` var `include_ping_test` reverts to a default value of "no"