### PR TITLE
FIX: couple of typos ; moving flavor to env variable

### DIFF
--- a/package/packer/openstack/template.json
+++ b/package/packer/openstack/template.json
@@ -1,7 +1,8 @@
 {
-  "_comment:": "OS_PACKER_SOURCE_IMAGE_ID is the OpenStack Glance Image Id of the Ubuntu 18.04 image that has been already uploaded into glacee",
+  "_comment:": "OS_SOURCE_IMAGE_ID is the OpenStack Glance Image Id of the Ubuntu 18.04 image that has been already uploaded into glance",
   "_comment:": "OS_NETWORKS_ID is the ID under the name of the nework located under Networks in the Horizion WebUI ",
   "_comment:": "OS_FLOATING_IP_POOL is the name of the OpenStack floating ip network to use",
+  "_comment:": "OS_FLAVOR is the name of the OpenStack flavor to use",
   "_comment:": "Packer needed to be rebuiled from source during the making of this due the the following issue: https://github.com/hashicorp/packer/issues/8258",
   "variables": {
     "os_auth_url": "{{env `OS_AUTH_URL`}}",
@@ -12,20 +13,23 @@
     "os_source_image_id": "{{env `OS_SOURCE_IMAGE`}}",
     "os_networks_id": "{{env `OS_NETWORKS_ID`}}",
     "os_floating_ip_pool": "{{env `OS_FLOATING_IP_POOL`}}",
+    "os_flavor": "{{env `OS_FLAVOR`}}",
     "k3os_version": "v0.5.0",
     "iso_url": "https://github.com/rancher/k3os/releases/download/v0.5.0/k3os-amd64.iso"
   },
   "builders": [
     {
-     "type": "openstack",
-     "flavor": "2",
-     "ssh_username": "ubuntu",
-     "image_name":  "k3OS-{{user `k3os_version`}}-amd64",
-     "source_image": "{{user `os_source_image_id`}}",
-     "networks": "{{user `os_networks_id`}}",
-     "floating_ip_pool": "{{user `os_floating_ip_pool`}}",
-     "use_floating_ip": true,
-     "security_groups": ["default"]
+      "type": "openstack",
+      "flavor": "{{user `os_flavor`}}",
+      "ssh_username": "ubuntu",
+      "image_name": "k3OS-{{user `k3os_version`}}-amd64",
+      "source_image": "{{user `os_source_image_id`}}",
+      "networks": "{{user `os_networks_id`}}",
+      "floating_ip_pool": "{{user `os_floating_ip_pool`}}",
+      "use_floating_ip": true,
+      "security_groups": [
+        "default"
+      ]
     }
   ],
   "provisioners": [


### PR DESCRIPTION
Small change to sort a few typos and create a variable for Openstack flavors