### PR TITLE
Add htop

### DIFF
--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -19,6 +19,7 @@ RUN apk --no-cache add \
     findutils \
     grub-efi \
     haveged \
+    htop \
     iproute2 \
     iptables \
     jq \


### PR DESCRIPTION
Fixes #265.

Feel free to close if `htop` isn't something you want to include in k3os.