### PR TITLE
ccapply: add label with the value of k3os.mode

### DIFF
--- a/pkg/cc/funcs.go
+++ b/pkg/cc/funcs.go
@@ -137,6 +137,9 @@ func ApplyK3S(cfg *config.CloudConfig, restart, install bool) error {
 	for k, v := range cfg.K3OS.Labels {
 		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
 	}
+	if mode != "" {
+		labels = append(labels, fmt.Sprintf("k3os.io/mode=%s", mode))
+	}
 	sort.Strings(labels)
 
 	for _, l := range labels {


### PR DESCRIPTION
If the `k3os.mode` (read from `/var/run/k3os/mode`) is not empty then add node-label `k3os.io/mode=${k3os.mode}`.

This allows for node affinities/anti-affinities dependent on the mode or for scheduling of daemonset pods for the k3os operator only on nodes where this label is present.