### PR TITLE
scripts/run-qemu: enable host qga socket by default

### DIFF
--- a/scripts/run-qemu
+++ b/scripts/run-qemu
@@ -38,6 +38,9 @@ exec $QEMU_SYSTEM \
     -nographic \
     -serial mon:stdio \
     -rtc base=utc,clock=rt \
+    -chardev socket,path=$STATE_DIR/qga.sock,server,nowait,id=qga0 \
+    -device virtio-serial \
+    -device virtserialport,chardev=qga0,name=org.qemu.guest_agent.0 \
     -kernel $(dirname $0)/../dist/artifacts/k3os-vmlinuz-$ARCH \
     -initrd $(dirname $0)/../dist/artifacts/k3os-initrd-$ARCH \
     -drive if=ide,media=cdrom,file=$(dirname $0)/../dist/artifacts/k3os-$ARCH.iso \


### PR DESCRIPTION
With this change, invoking `scripts/run-qemu` with this following arguments will result in the activation of qemu-guest-agent in the guest VM:
- `k3os.mode=live`
- `'boot_cmd="echo GA_PATH=/dev/vport0p1>/etc/conf.d/qemu-guest-agent"'`

Unless the `$STATE_DIR` envvar is overridden, the `qga.sock` will be in the `build/state/k3os-$TAG` directory.
e.g.
`echo '{"execute":"guest-get-osinfo"}' | socat unix-connect:/tmp/qga.sock stdout`

Addresses #291 