### PR TITLE
Use interal-sftp instead of sftp-server

### DIFF
--- a/overlay/libexec/k3os/mode-local
+++ b/overlay/libexec/k3os/mode-local
@@ -8,6 +8,7 @@ setup_ssh()
     fi
     rm -rf /etc/ssh
     ln -s /var/lib/rancher/k3os/ssh /etc/ssh
+    sed -i 's:/usr/lib/ssh/sftp-server:internal-sftp:g' /etc/ssh/sshd_config
 }
 
 setup_rancher_node()


### PR DESCRIPTION
Chose to put this in `mode-local`'s `setup_ssh` instead of the `boot`/`bootstrap` scripts as there were already a ssh setup script here.

Fixes #317.