### PR TITLE
sshd_config: establish default values in overlay

### DIFF
--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -37,7 +37,6 @@ RUN apk --no-cache add \
     procps \
     qemu-guest-agent \
     rng-tools \
-    rng-tools-openrc \
     rsync \
     strace \
     sudo \

--- a/overlay/etc/ssh/sshd_config
+++ b/overlay/etc/ssh/sshd_config
@@ -1,0 +1,9 @@
+# See https://man.openbsd.org/sshd_config for
+# details on these and other parameters.
+
+AllowTcpForwarding      no
+GatewayPorts            no
+PasswordAuthentication  no
+X11Forwarding           no
+
+Subsystem   sftp    internal-sftp


### PR DESCRIPTION
Add default, secure values for `/etc/ssh/sshd_config` via overlay. Importantly, this means that `PasswordAuthentication=no` by default which is a change from previous releases.

Fixes #317
Fixes #262