### PR TITLE
cli: upgrade sub-command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/mattn/go-isatty v0.0.10
+	github.com/otiai10/copy v1.0.2
 	github.com/pkg/errors v0.8.1
 	github.com/rancher/mapper v0.0.0-20190814232720-058a8b7feb99
 	github.com/rancher/wrangler v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,12 @@ github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/otiai10/copy v1.0.2 h1:DDNipYy6RkIkjMwy+AWzgKiNTyj2RUI9yEMeETEpVyc=
+github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ryit9KGfp3sUsW4Lqg32iRMJyzs=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/pkg/cli/app/app.go
+++ b/pkg/cli/app/app.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/k3os/pkg/cli/config"
 	"github.com/rancher/k3os/pkg/cli/install"
 	"github.com/rancher/k3os/pkg/cli/rc"
-	"github.com/rancher/k3os/pkg/mode"
+	"github.com/rancher/k3os/pkg/cli/upgrade"
 	"github.com/rancher/k3os/pkg/version"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -38,9 +38,8 @@ func New() *cli.App {
 	app.Commands = []cli.Command{
 		rc.Command(),
 		config.Command(),
-	}
-	if mode, _ := mode.Get(); mode != "local" {
-		app.Commands = append(app.Commands, install.Command())
+		install.Command(),
+		upgrade.Command(),
 	}
 
 	app.Before = func(c *cli.Context) error {

--- a/pkg/cli/install/install.go
+++ b/pkg/cli/install/install.go
@@ -5,11 +5,13 @@ import (
 	"os"
 
 	"github.com/rancher/k3os/pkg/cliinstall"
+	"github.com/rancher/k3os/pkg/mode"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
 func Command() cli.Command {
+	mode, _ := mode.Get()
 	return cli.Command{
 		Name:  "install",
 		Usage: "install k3OS",
@@ -25,5 +27,6 @@ func Command() cli.Command {
 				logrus.Error(err)
 			}
 		},
+		Hidden: mode == "local",
 	}
 }

--- a/pkg/cli/upgrade/upgrade.go
+++ b/pkg/cli/upgrade/upgrade.go
@@ -1,0 +1,197 @@
+package upgrade
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/rancher/k3os/pkg/system"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	upgradeK3OS, upgradeK3S             bool
+	upgradeKernel, upgradeRootFS        bool
+	doRemount, doSync, doReboot         bool
+	sourceDir, destinationDir, lockFile string
+)
+
+// Command is the `upgrade` sub-command, it performs upgrades to k3OS.
+func Command() cli.Command {
+	return cli.Command{
+		Name:  "upgrade",
+		Usage: "perform upgrades",
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:        "k3os",
+				EnvVar:      "K3OS_UPGRADE_K3OS",
+				Destination: &upgradeK3OS,
+				Hidden:      true,
+			},
+			cli.BoolFlag{
+				Name:        "k3s",
+				EnvVar:      "K3OS_UPGRADE_K3S",
+				Destination: &upgradeK3S,
+				Hidden:      true,
+			},
+			cli.BoolFlag{
+				Name:        "kernel",
+				Usage:       "upgrade the kernel",
+				EnvVar:      "K3OS_UPGRADE_KERNEL",
+				Destination: &upgradeKernel,
+			},
+			cli.BoolFlag{
+				Name:        "rootfs",
+				Usage:       "upgrade k3os+k3s",
+				EnvVar:      "K3OS_UPGRADE_ROOTFS",
+				Destination: &upgradeRootFS,
+			},
+			cli.BoolFlag{
+				Name:        "remount",
+				Usage:       "pre-upgrade remount?",
+				EnvVar:      "K3OS_UPGRADE_REMOUNT",
+				Destination: &doRemount,
+			},
+			cli.BoolFlag{
+				Name:        "sync",
+				Usage:       "post-upgrade sync?",
+				EnvVar:      "K3OS_UPGRADE_SYNC",
+				Destination: &doSync,
+			},
+			cli.BoolFlag{
+				Name:        "reboot",
+				Usage:       "post-upgrade reboot?",
+				EnvVar:      "K3OS_UPGRADE_REBOOT",
+				Destination: &doReboot,
+			},
+			cli.StringFlag{
+				Name:        "source",
+				EnvVar:      "K3OS_UPGRADE_SOURCE",
+				Value:       system.RootPath(),
+				Required:    true,
+				Destination: &sourceDir,
+			},
+			cli.StringFlag{
+				Name:        "destination",
+				EnvVar:      "K3OS_UPGRADE_DESTINATION",
+				Value:       system.RootPath(),
+				Required:    true,
+				Destination: &destinationDir,
+			},
+			cli.StringFlag{
+				Name:        "lock-file",
+				EnvVar:      "K3OS_UPGRADE_LOCK_FILE",
+				Value:       system.StatePath("upgrade.lock"),
+				Hidden:      true,
+				Destination: &lockFile,
+			},
+		},
+		Before: func(c *cli.Context) error {
+			if destinationDir == sourceDir {
+				cli.ShowSubcommandHelp(c)
+				logrus.Errorf("the `destination` cannot be the `source`: %s", destinationDir)
+				os.Exit(1)
+			}
+			if upgradeRootFS {
+				upgradeK3S = true
+				upgradeK3OS = true
+			}
+			if !upgradeK3OS && !upgradeK3S && !upgradeKernel {
+				cli.ShowSubcommandHelp(c)
+				logrus.Error("must specify components to upgrade, e.g. `rootfs`, `kernel`")
+				os.Exit(1)
+			}
+			return nil
+		},
+		Action: Run,
+	}
+}
+
+// Run the `upgrade` sub-command
+func Run(_ *cli.Context) {
+	if err := validateSystemRoot(sourceDir); err != nil {
+		logrus.Fatal(err)
+	}
+	if err := validateSystemRoot(destinationDir); err != nil {
+		logrus.Fatal(err)
+	}
+
+	// establish the lock
+	lf, err := os.OpenFile(lockFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	defer lf.Close()
+	if err = unix.Flock(int(lf.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		logrus.Fatal(err)
+	}
+	defer unix.Flock(int(lf.Fd()), unix.LOCK_UN)
+
+	var atLeastOneComponentCopied bool
+
+	if upgradeK3OS {
+		if copied, err := system.CopyComponent(sourceDir, destinationDir, doRemount, "k3os"); err != nil {
+			logrus.Error(err)
+		} else if copied {
+			atLeastOneComponentCopied = true
+			doRemount = false
+		}
+	}
+	if upgradeK3S {
+		if copied, err := system.CopyComponent(sourceDir, destinationDir, doRemount, "k3s"); err != nil {
+			logrus.Error(err)
+		} else if copied {
+			atLeastOneComponentCopied = true
+			doRemount = false
+		}
+	}
+	if upgradeKernel {
+		if copied, err := system.CopyComponent(sourceDir, destinationDir, doRemount, "kernel"); err != nil {
+			logrus.Error(err)
+		} else if copied {
+			atLeastOneComponentCopied = true
+			doRemount = false
+		}
+	}
+
+	if atLeastOneComponentCopied && doSync {
+		unix.Sync()
+	}
+
+	if atLeastOneComponentCopied && doReboot {
+		// nsenter -m -u -i -n -p -t 1 -- reboot
+		if _, err := exec.LookPath("nsenter"); err != nil {
+			logrus.Warn(err)
+			if destinationDir != system.RootPath() {
+				root := filepath.Clean(filepath.Join(destinationDir, "..", ".."))
+				logrus.Debugf("attempting chroot: %v", root)
+				if err := unix.Chroot(root); err != nil {
+					logrus.Fatal(err)
+				}
+				if err := os.Chdir("/"); err != nil {
+					logrus.Fatal(err)
+				}
+			}
+		}
+		cmd := exec.Command("nsenter", "-m", "-u", "-i", "-n", "-p", "-t", "1", "reboot")
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		if err := cmd.Run(); err != nil {
+			logrus.Fatal(err)
+		}
+	}
+}
+
+func validateSystemRoot(root string) error {
+	info, err := os.Stat(root)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("stat %s: not a directory", root)
+	}
+	return nil
+}

--- a/pkg/system/component.go
+++ b/pkg/system/component.go
@@ -1,0 +1,111 @@
+package system
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/pkg/mount"
+	"github.com/otiai10/copy"
+	"github.com/sirupsen/logrus"
+)
+
+type VersionName string
+
+const (
+	VersionCurrent  VersionName = "current"
+	VersionPrevious VersionName = "previous"
+)
+
+func StatComponentVersion(root, key string, alias VersionName) (os.FileInfo, error) {
+	currentPath := filepath.Join(root, key, string(alias))
+	currentInfo, err := os.Stat(currentPath)
+	if err != nil {
+		return nil, err
+	}
+	if !currentInfo.IsDir() {
+		return nil, fmt.Errorf("stat %s: not a directory", currentPath)
+	}
+	version, err := os.Readlink(currentPath)
+	if err != nil {
+		return nil, err
+	}
+	versionPath := filepath.Join(root, key, version)
+	versionInfo, err := os.Stat(versionPath)
+	if err != nil {
+		return nil, err
+	}
+	if !versionInfo.IsDir() {
+		return versionInfo, fmt.Errorf("stat %s: not a directory", versionPath)
+	}
+	return versionInfo, nil
+}
+
+func CopyComponent(src, dst string, remount bool, key string) (bool, error) {
+	srcInfo, err := StatComponentVersion(src, key, VersionCurrent)
+	if err != nil {
+		return false, err
+	}
+	dstInfo, _ := StatComponentVersion(dst, key, VersionCurrent)
+	if dstInfo != nil && dstInfo.Name() == srcInfo.Name() {
+		logrus.Infof("skipping %q because destination version matches source: %s", key, dstInfo.Name())
+		return false, nil
+	}
+	if remount {
+		if err := mount.Mount("", dst, "none", "remount,rw"); err != nil {
+			return false, err
+		}
+	}
+
+	srcPath := filepath.Join(src, key, srcInfo.Name())
+	dstPath := filepath.Join(dst, key, srcInfo.Name())
+	dstPrevPath := filepath.Join(dst, key, string(VersionPrevious))
+	dstCurrPath := filepath.Join(dst, key, string(VersionCurrent))
+
+	dstCurrTemp := dstCurrPath + `.tmp`
+	if err := os.Symlink(filepath.Base(dstPath), dstCurrTemp); err != nil {
+		return false, err
+	}
+	logrus.Debugf("created symlink: %v", dstCurrTemp)
+	defer os.Remove(dstCurrTemp) // if this fails, that means it's gone which is correct
+
+	dstTemp, err := ioutil.TempDir(filepath.Split(dstPath))
+	if err != nil {
+		return false, err
+	}
+	logrus.Debugf("created temporary dir: %v", dstTemp)
+	defer os.RemoveAll(dstTemp) // if this fails, that means it's gone which is correct
+
+	logrus.Debugf("copying: %v -> %v", srcPath, dstTemp)
+	if err := copy.Copy(srcPath, dstTemp); err != nil {
+		return false, err
+	}
+
+	logrus.Debugf("renaming: %v -> %v", dstTemp, dstPath)
+	if err := os.Rename(dstTemp, dstPath); err != nil {
+		return false, err
+	}
+
+	logrus.Debugf("chmod %s %s", srcInfo.Mode(), dstPath)
+	if err := os.Chmod(dstPath, srcInfo.Mode()); err != nil {
+		logrus.Error(err)
+	}
+
+	logrus.Debugf("removing: %v", dstPrevPath)
+	if err := os.Remove(dstPrevPath); err != nil {
+		logrus.Warn(err)
+	}
+
+	logrus.Debugf("copying: %v -> %v", dstCurrPath, dstPrevPath)
+	if err := copy.Copy(dstCurrPath, dstPrevPath); err != nil {
+		logrus.Error(err)
+	}
+
+	logrus.Debugf("renaming: %v -> %v", dstCurrTemp, dstCurrPath)
+	if err := os.Rename(dstCurrTemp, dstCurrPath); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/vendor/github.com/otiai10/copy/.gitignore
+++ b/vendor/github.com/otiai10/copy/.gitignore
@@ -1,0 +1,3 @@
+testdata.copy
+coverage.txt
+vendor

--- a/vendor/github.com/otiai10/copy/.travis.yml
+++ b/vendor/github.com/otiai10/copy/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go:
+    - 1.9
+    - tip
+before_script:
+    - go get -t ./...
+script:
+    - go test ./... -v
+    - go test -race -coverprofile=coverage.txt -covermode=atomic
+after_success:
+    - bash <(curl -s https://codecov.io/bash)

--- a/vendor/github.com/otiai10/copy/LICENSE
+++ b/vendor/github.com/otiai10/copy/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 otiai10
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/otiai10/copy/README.md
+++ b/vendor/github.com/otiai10/copy/README.md
@@ -1,0 +1,14 @@
+# copy
+
+[![Build Status](https://travis-ci.org/otiai10/copy.svg?branch=master)](https://travis-ci.org/otiai10/copy)
+[![codecov](https://codecov.io/gh/otiai10/copy/branch/master/graph/badge.svg)](https://codecov.io/gh/otiai10/copy)
+[![GoDoc](https://godoc.org/github.com/otiai10/copy?status.svg)](https://godoc.org/github.com/otiai10/copy)
+[![Go Report Card](https://goreportcard.com/badge/github.com/otiai10/copy)](https://goreportcard.com/report/github.com/otiai10/copy)
+
+`copy` copies directories recursively.
+
+Example:
+
+```go
+err := Copy("your/directory", "your/directory.copy")
+```

--- a/vendor/github.com/otiai10/copy/copy.go
+++ b/vendor/github.com/otiai10/copy/copy.go
@@ -1,0 +1,106 @@
+package copy
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// tmpPermissionForDirectory makes the destination directory writable,
+	// so that stuff can be copied recursively even if any original directory is NOT writable.
+	// See https://github.com/otiai10/copy/pull/9 for more information.
+	tmpPermissionForDirectory = os.FileMode(0755)
+)
+
+// Copy copies src to dest, doesn't matter if src is a directory or a file
+func Copy(src, dest string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	return copy(src, dest, info)
+}
+
+// copy dispatches copy-funcs according to the mode.
+// Because this "copy" could be called recursively,
+// "info" MUST be given here, NOT nil.
+func copy(src, dest string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return lcopy(src, dest, info)
+	}
+	if info.IsDir() {
+		return dcopy(src, dest, info)
+	}
+	return fcopy(src, dest, info)
+}
+
+// fcopy is for just a file,
+// with considering existence of parent directory
+// and file permission.
+func fcopy(src, dest string, info os.FileInfo) error {
+
+	if err := os.MkdirAll(filepath.Dir(dest), os.ModePerm); err != nil {
+		return err
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err = os.Chmod(f.Name(), info.Mode()); err != nil {
+		return err
+	}
+
+	s, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	_, err = io.Copy(f, s)
+	return err
+}
+
+// dcopy is for a directory,
+// with scanning contents inside the directory
+// and pass everything to "copy" recursively.
+func dcopy(srcdir, destdir string, info os.FileInfo) error {
+
+	originalMode := info.Mode()
+
+	// Make dest dir with 0755 so that everything writable.
+	if err := os.MkdirAll(destdir, tmpPermissionForDirectory); err != nil {
+		return err
+	}
+	// Recover dir mode with original one.
+	defer os.Chmod(destdir, originalMode)
+
+	contents, err := ioutil.ReadDir(srcdir)
+	if err != nil {
+		return err
+	}
+
+	for _, content := range contents {
+		cs, cd := filepath.Join(srcdir, content.Name()), filepath.Join(destdir, content.Name())
+		if err := copy(cs, cd, content); err != nil {
+			// If any error, exit immediately
+			return err
+		}
+	}
+
+	return nil
+}
+
+// lcopy is for a symlink,
+// with just creating a new symlink by replicating src symlink.
+func lcopy(src, dest string, info os.FileInfo) error {
+	src, err := os.Readlink(src)
+	if err != nil {
+		return err
+	}
+	return os.Symlink(src, dest)
+}

--- a/vendor/github.com/otiai10/copy/go.mod
+++ b/vendor/github.com/otiai10/copy/go.mod
@@ -1,0 +1,5 @@
+module github.com/otiai10/copy
+
+go 1.12
+
+require github.com/otiai10/mint v1.3.0

--- a/vendor/github.com/otiai10/copy/go.sum
+++ b/vendor/github.com/otiai10/copy/go.sum
@@ -1,0 +1,3 @@
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,6 +13,8 @@ github.com/konsorten/go-windows-terminal-sequences
 github.com/mattn/go-isatty
 # github.com/mattn/go-shellwords v1.0.5
 github.com/mattn/go-shellwords
+# github.com/otiai10/copy v1.0.2
+github.com/otiai10/copy
 # github.com/pkg/errors v0.8.1
 github.com/pkg/errors
 # github.com/rancher/mapper v0.0.0-20190814232720-058a8b7feb99


### PR DESCRIPTION
Introducting `k3os upgrade` and hiding `k3os install` when `k3os.mode` == `local`:

```
$ k3os upgrade --help
NAME:
   k3os upgrade - perform upgrades

USAGE:
   k3os upgrade [command options] [arguments...]

OPTIONS:
   --kernel             upgrade the kernel [$K3OS_UPGRADE_KERNEL]
   --rootfs             upgrade k3os+k3s [$K3OS_UPGRADE_ROOTFS]
   --remount            pre-upgrade remount? [$K3OS_UPGRADE_REMOUNT]
   --sync               post-upgrade sync? [$K3OS_UPGRADE_SYNC]
   --reboot             post-upgrade reboot? [$K3OS_UPGRADE_REBOOT]
   --source value       (default: "/k3os/system") [$K3OS_UPGRADE_SOURCE]
   --destination value  (default: "/k3os/system") [$K3OS_UPGRADE_DESTINATION]
```

This enables the future system-upgrade-controller integration, or similar, that run from within the `rancher/k3os` container and mount the host's root to /host and then pass `/host/k3os/system` as destination.
Invoking `k3os upgrade` from within a container and passing `--reboot`, assuming the destination is mutated, requires host IPC and PID namespaces along with it being privileged so that it may chroot to /host and then invoke `nsenter` into PID 1 to invoke `reboot`.