### PR TITLE
udev-trigger as sysinit service

### DIFF
--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -54,4 +54,5 @@ RUN apk --no-cache add \
     xz \
  && mv -vf /etc/conf.d/qemu-guest-agent /etc/conf.d/qemu-guest-agent.orig \
  && mv -vf /etc/conf.d/rngd             /etc/conf.d/rngd.orig \
+ && mv -vf /etc/conf.d/udev-settle      /etc/conf.d/udev-settle.orig \
  && true

--- a/overlay/libexec/k3os/boot
+++ b/overlay/libexec/k3os/boot
@@ -33,7 +33,7 @@ setup_sudoers()
 
 setup_services()
 {
-    for i in hwdrivers udev dmesg devfs loadkmap; do
+    for i in hwdrivers dmesg devfs loadkmap udev udev-trigger; do
         ln -s /etc/init.d/$i /etc/runlevels/sysinit
     done
 
@@ -53,6 +53,9 @@ setup_services()
 setup_config()
 {
     k3os config --boot
+    if [ -e /etc/conf.d/udev-settle ]; then
+        ln -s /etc/init.d/udev-settle /etc/runlevels/sysinit/
+    fi
     if [ -e /var/lib/connman/cloud-config.config ]; then
         echo 'rc_want="wpa_supplicant"' >> /etc/conf.d/connman
     fi


### PR DESCRIPTION
udev-settle is added to sysinit if `/etc/conf.d/udev-settle` is present

Fixes #151 