### PR TITLE
Allow v0.9.0 to silent install via netboot with kernel&initrd issue #56

### DIFF
--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -52,6 +52,7 @@ RUN apk --no-cache add \
     util-linux \
     vim \
     xz \
+    dhclient \
  && mv -vf /etc/conf.d/qemu-guest-agent /etc/conf.d/qemu-guest-agent.orig \
  && mv -vf /etc/conf.d/rngd             /etc/conf.d/rngd.orig \
  && mv -vf /etc/conf.d/udev-settle      /etc/conf.d/udev-settle.orig \

--- a/overlay/libexec/k3os/boot
+++ b/overlay/libexec/k3os/boot
@@ -117,6 +117,23 @@ setup_hostname()
 
 setup_mounts()
 {
+
+    for x in $(cat /proc/cmdline); do
+         case $x in
+            k3os.install.iso_url=*)
+                INSTALL_ISO_URL=${x#k3os.install.iso_url=}
+                ;;
+         esac
+    done
+
+    if [ -v INSTALL_ISO_URL ]; then
+        pinfo NETBOOT Activating eth0 to download ${INSTALL_ISO_URL}
+        dhclient eth0
+        K3OS_LOCAL_ISO_PATH="/tmp/k3os-install-iso.iso" 
+        pinfo NETBOOT Downloading K3OS ISO from ${INSTALL_ISO_URL}
+        wget ${INSTALL_ISO_URL} -O ${K3OS_LOCAL_ISO_PATH} && mount ${K3OS_LOCAL_ISO_PATH} /.base
+    fi
+        
     if [ -d /.base/boot ]; then
         mkdir -p /boot
         mount --bind /.base/boot /boot


### PR DESCRIPTION
Hi all,
I really needed silent install functionality via iPXE/Netboot functionality so looked into this old issue. Have documented the issues I was running into in #56 

While this does work and i'm able to silent install v0.9.0 via netboot by setting the `k3os.install.iso_url` kernel arg, I'm concerned a lot of people are potentially using the `k3os.install.iso_url` flag to point the installer to their own customized ISO's in non-netboot scenarios, and the flag may be used beyond it's description in the docs? If so, maybe a new `k3os.install.netboot=true` flag to hide this type of "extra download step" functionality behind?

PS, first PR to the project, build process with make and dapper was super painless and easy to understand. Made getting involved easier than expected, thanks for all the hard work!