### PR TITLE
init: split udev-trigger into root+coldplug

### DIFF
--- a/overlay/etc/conf.d/udev-coldplug
+++ b/overlay/etc/conf.d/udev-coldplug
@@ -1,0 +1,23 @@
+# /etc/conf.d/udev-coldplug: config file for udev-coldplug
+
+# udev can trigger coldplug events which cause services to start and
+# kernel modules to be loaded.
+# Services are deferred to start in the boot runlevel.
+# Set rc_coldplug="NO" if you don't want this.
+# If you want module coldplugging but not coldplugging of services then you
+# can disable service coldplugging in baselayout/openrc config files.
+# The setting is named different in different versions.
+# in /etc/rc.conf: rc_hotplug="!*" or
+# in /etc/conf.d/rc: rc_plug_services="!*"
+#rc_coldplug="yes"
+
+# Run udevadmin monitor to get a log of all events
+# in /run/udevmonitor.log
+#udev_monitor="yes"
+
+# Keep udevmonitor running after populating /dev.
+#udev_monitor_keep_running="no"
+
+# Set cmdline options for udevmonitor.
+# could be some of --env --kernel --udev
+#udev_monitor_opts="--env"

--- a/overlay/etc/conf.d/udev-root
+++ b/overlay/etc/conf.d/udev-root
@@ -1,0 +1,10 @@
+# /etc/conf.d/udev-root: config file for udev-root
+
+# We can create a /dev/root symbolic link to point to the root device in
+# some situations. This is on by default because some software relies on
+# it,. However, this software should be fixed to not do this.
+# For more information, see
+# https://bugs.gentoo.org/show_bug.cgi?id=438380.
+# If you are not using any affected software, you do not need this, so
+# feel free to turn it off.
+#rc_dev_root_symlink="yes"

--- a/overlay/etc/init.d/udev-coldplug
+++ b/overlay/etc/init.d/udev-coldplug
@@ -1,0 +1,72 @@
+#!/sbin/openrc-run
+# Copyright 2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+description="udev coldplug all devices"
+
+udevmonitor_log=/run/udevmonitor.log
+udevmonitor_pid=/run/udevmonitor.pid
+
+depend()
+{
+	need udev hwdrivers modules
+	provide dev-coldplug
+	keyword -lxc -systemd-nspawn -vserver
+}
+
+start_pre()
+{
+	if yesno "${udev_monitor:-no}"; then
+		einfo "Running udevadm monitor ${udev_monitor_opts} to log all events"
+		start-stop-daemon --start --stdout "${udevmonitor_log}" \
+			--make-pidfile --pidfile "${udevmonitor_pid}" \
+			--background --exec /bin/udevadm -- monitor ${udev_monitor_opts}
+	fi
+	return 0
+}
+
+display_hotplugged_services()
+{
+	local svcfile= svc= services=
+	for svcfile in "${RC_SVCDIR}"/hotplugged/*; do
+		svc="${svcfile##*/}"
+		[ -x "${svcfile}" ] || continue
+
+		services="${services} ${svc}"
+	done
+	[ -n "${services}" ] && einfo "Device initiated services:${HILITE}${services}${NORMAL}"
+	return 0
+}
+
+start_post()
+{
+	if yesno "${udev_monitor:-no}"; then
+		if yesno "${udev_monitor_keep_running:-no}"; then
+			ewarn "udevmonitor is still writing into ${udevmonitor_log}"
+		else
+			einfo "Stopping udevmonitor: Log is in ${udevmonitor_log}"
+			start-stop-daemon --stop --pidfile "${udevmonitor_pid}" \
+				--exec /bin/udevadm
+		fi
+	fi
+	display_hotplugged_services
+	return 0
+}
+
+start()
+{
+	get_bootparam "nocoldplug" && rc_coldplug="no"
+	if ! yesno ${rc_coldplug:-${RC_COLDPLUG:-yes}}; then
+		einfo "Setting /dev permissions and symbolic links"
+		udevadm trigger --attr-match=dev --action=add
+		udevadm trigger --subsystem-match=net --action=add
+		rc=$?
+		ewarn "Skipping udev coldplug sequence"
+		return $rc
+	fi
+
+	ebegin "Populating /dev with existing devices through uevents"
+	udevadm trigger --type=subsystems --action=add
+	udevadm trigger --type=devices --action=add
+	eend $?
+}

--- a/overlay/etc/init.d/udev-root
+++ b/overlay/etc/init.d/udev-root
@@ -1,0 +1,39 @@
+#!/sbin/openrc-run
+# Copyright 2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+description="udev root symlink"
+
+depend()
+{
+	need udev hwdrivers modules
+	provide dev-root
+	before udev-coldplug
+	keyword -lxc -systemd-nspawn -vserver
+}
+
+# This is here because some software expects /dev/root to exist.
+# For more information, see this bug:
+# https://bugs.gentoo.org/show_bug.cgi?id=438380
+dev_root_link()
+{
+	local RULESDIR=/run/udev/rules.d
+	[ -d $RULESDIR ] || mkdir -p $RULESDIR
+	eval $(udevadm info --export --export-prefix=ROOT_ --device-id-of-file=/ || true)
+	[ "$ROOT_MAJOR" -a "$ROOT_MINOR" ] || return 0
+
+	# btrfs filesystems have bogus major/minor numbers
+	[ "$ROOT_MAJOR" != 0 ] || return 0
+
+	echo 'ACTION=="add|change", SUBSYSTEM=="block", ENV{MAJOR}=="'$ROOT_MAJOR'", ENV{MINOR}=="'$ROOT_MINOR'", SYMLINK+="root"' > $RULESDIR/61-dev-root-link.rules
+	return 0
+}
+
+start()
+{
+	if yesno ${rc_dev_root_symlink:-yes}; then
+		ebegin "Generating a rule to create a /dev/root symlink"
+		dev_root_link
+		eend $?
+	fi
+}

--- a/overlay/libexec/k3os/boot
+++ b/overlay/libexec/k3os/boot
@@ -33,7 +33,7 @@ setup_sudoers()
 
 setup_services()
 {
-    for i in hwdrivers dmesg devfs loadkmap udev udev-trigger; do
+    for i in hwdrivers dmesg devfs loadkmap udev udev-root udev-coldplug; do
         ln -s /etc/init.d/$i /etc/runlevels/sysinit
     done
 


### PR DESCRIPTION
This address a gap created by `udev-trigger` performing coldplug initialization prior to `hwdrivers` loading modules for detected hardware.

Fixes #426