### PR TITLE
base: add tzdata and ncurses-terminfo

### DIFF
--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -37,6 +37,7 @@ RUN apk --no-cache add \
     mdadm-udev \
     multipath-tools \
     ncurses \
+    ncurses-terminfo \
     nfs-utils \
     open-iscsi \
     openrc \
@@ -50,6 +51,7 @@ RUN apk --no-cache add \
     strace \
     sudo \
     tar \
+    tzdata \
     util-linux \
     vim \
     xz \


### PR DESCRIPTION
Address #103 by allowing installations to set timezone, e.g. for `America/Phoenix`:
```bash
ln -vs /usr/share/zoneinfo/America/Phoenix /etc/localtime
echo 'America/Phoenix' > /etc/timezone
```

Address an issue caused by Alpine upstream refactoring terminfo
packaging with ncurses.