### PR TITLE
iso: fix usb image

### DIFF
--- a/images/10-kernel-stage1/Dockerfile
+++ b/images/10-kernel-stage1/Dockerfile
@@ -1,9 +1,19 @@
 ARG REPO
 ARG TAG
-FROM ubuntu:disco
+FROM ubuntu:focal
 
-RUN apt-get update -y && \
-    apt-get install -y kmod initramfs-tools curl rsync xz-utils
+RUN apt-get --assume-yes update \
+ && apt-get --assume-yes install \
+    curl \
+    initramfs-tools \
+    kmod \
+    lz4 \
+    rsync \
+    xz-utils \
+ && echo 'hfs' >> /etc/initramfs-tools/modules \
+ && echo 'hfsplus' >> /etc/initramfs-tools/modules \
+ && echo 'nls_utf8' >> /etc/initramfs-tools/modules \
+ && echo 'nls_iso8859_1' >> /etc/initramfs-tools/modules
 
 ARG ARCH
 ENV KVERSION=5.0.0-43-generic
@@ -29,13 +39,13 @@ RUN mkdir -p /usr/src/root && \
 RUN mkdir /usr/src/initrd && \
     rsync -a /usr/src/root/lib/ /lib/ && \
     depmod $KVERSION && \
-    mkinitramfs -k $KVERSION -o /usr/src/initrd.tmp
+    mkinitramfs -k $KVERSION -c lz4 -o /usr/src/initrd.tmp
 
 # Generate initrd firmware and module lists
 RUN mkdir -p /output/lib && \
     mkdir -p /output/headers && \
     cd /usr/src/initrd && \
-    gzip -dc /usr/src/initrd.tmp | cpio -idmv && \
+    lz4cat /usr/src/initrd.tmp | cpio -idmv && \
     find lib/modules -name \*.ko > /output/initrd-modules && \
     echo lib/modules/${KVERSION}/modules.order >> /output/initrd-modules && \
     echo lib/modules/${KVERSION}/modules.builtin >> /output/initrd-modules && \

--- a/images/70-iso/Dockerfile
+++ b/images/70-iso/Dockerfile
@@ -20,11 +20,9 @@ COPY grub.cfg /usr/src/iso/boot/grub/grub.cfg
 
 COPY --from=package /output/ /usr/src/iso/
 
-COPY wrapper /usr/bin/
 COPY config.yaml /usr/src/iso/k3os/system/
 RUN mkdir -p /output && \
-    cd /usr/src/iso && \
-    grub-mkrescue --xorriso=/usr/bin/wrapper -o /output/k3os.iso . -V K3OS && \
+    grub-mkrescue -o /output/k3os.iso /usr/src/iso/. -- -volid K3OS -joliet on && \
     [ -e /output/k3os.iso ] # grub-mkrescue doesn't exit non-zero on failure
 
 CMD ["run-kvm.sh"]

--- a/images/70-iso/wrapper
+++ b/images/70-iso/wrapper
@@ -1,5 +1,0 @@
-#!/bin/bash
-A="$(echo "$@" | sed 's!-hfsplus -apm-block-size 2048 -hfsplus-file-creator-type chrp tbxj /System/Library/CoreServices/.disk_label -hfs-bless-by i /System/Library/CoreServices/boot.efi!!')"
-echo $A >> /tmp/args
-set -x
-exec xorriso -joliet on -rockridge on $A

--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,7 @@ do_format()
         parted -s ${DEVICE} mkpart primary ext4 0% 700MB
     fi
     parted -s ${DEVICE} set 1 ${BOOTFLAG} on
-    partprobe 2>/dev/null || true
+    partprobe ${DEVICE} 2>/dev/null || true
     sleep 2
 
     PREFIX=${DEVICE}
@@ -117,7 +117,7 @@ do_mount()
     fi
 
     mkdir -p $DISTRO
-    mount -t iso9660 -o ro $ISO_DEVICE $DISTRO
+    mount -o ro $ISO_DEVICE $DISTRO
 }
 
 do_copy()
@@ -206,7 +206,7 @@ get_iso()
     if [ -z "${ISO_DEVICE}" ]; then
         for i in $(lsblk -o NAME,TYPE -n | grep -w disk | awk '{print $1}'); do
             mkdir -p ${DISTRO}
-            if mount -t iso9660 -o ro /dev/$i ${DISTRO}; then
+            if mount -o ro /dev/$i ${DISTRO}; then
                 ISO_DEVICE="/dev/$i"
                 umount ${DISTRO}
                 break

--- a/overlay/libexec/k3os/live
+++ b/overlay/libexec/k3os/live
@@ -10,12 +10,12 @@ setup_base()
 {
     K3OS_ISO=$(blkid -L K3OS || true)
     if [ -n "$K3OS_ISO" ]; then
-        mount -t iso9660 -o ro $(blkid -L K3OS) /.base
+        mount -o ro $(blkid -L K3OS) /.base
     else
         success=false
         for (( j=0; j < 5 ; j++ )); do
             for i in $(lsblk -o NAME,TYPE -n | grep -w disk | awk '{print $1}'); do
-                if mount -t iso9660 /dev/$i /.base; then
+                if mount /dev/$i /.base; then
                     success=true
                     break
                 fi


### PR DESCRIPTION
At some point I broke the bootability of the ISO image from USB. It seems to be fixed now.

The inclusion of hfsplus/nls modules on the initrd enables the (previously disabled) booting of the embedded hfsplus partition created by grub-mkrescue.