### PR TITLE
Add etcd service and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ the cluster.
 ### Automatic Upgrades
 
 Integration with [rancher/system-upgrade-controller](https://github.com/rancher/system-upgrade-controller) has been implemented as of [v0.9.0](https://github.com/rancher/k3os/releases/tag/v0.9.0).
-To enable a k3OS node to automatically upgrade from the [latest GitHub release](https://github.com/rancher/k3os/releases/latest) you will need to make sure it has the label 
+To enable a k3OS node to automatically upgrade from the [latest GitHub release](https://github.com/rancher/k3os/releases/latest) you will need to make sure it has the label
 `plan.upgrade.cattle.io/k3os-latest` with a value anything other than `disabled`. The upgrade controller will then spawn an upgrade job
 that will drain most pods, upgrade the k3OS content under `/k3os/system`, and then reboot. The system should come back up running the latest
 kernel and k3s version bundled with k3OS and ready to schedule pods.
@@ -613,7 +613,7 @@ k3os:
   - "--service-cidr=10.107.1.0/23"
 
 # Effectively invokes k3s as:
-# exec "k3s" "server" "--cluster-cidr=10.107.0.0/23" "--service-cidr=10.107.1.0/23" 
+# exec "k3s" "server" "--cluster-cidr=10.107.0.0/23" "--service-cidr=10.107.1.0/23"
 ```
 
 ```yaml
@@ -627,7 +627,7 @@ k3os:
   - "10.107.1.0/23"
 
 # Effectively invokes k3s as:
-# exec "k3s" "server" "--cluster-cidr" "10.107.0.0/23" "--service-cidr" "10.107.1.0/23" 
+# exec "k3s" "server" "--cluster-cidr" "10.107.0.0/23" "--service-cidr" "10.107.1.0/23"
 ```
 
 ### `k3os.environment`
@@ -654,6 +654,36 @@ k3os:
   - "key1=value1:NoSchedule"
   - "key1=value1:NoExecute"
 ```
+
+### `k3os.etcd`
+
+Available for AMD64 and ARM64.
+
+Add the etcd service to the node which k3s can then use as a storage backend.
+
+The following variables can be used in the etcd args:
+
+ - ETCD_HOST_IP is the ip address of the etcd iface.
+ - ETCD_TOKEN is the etcd token.
+ - ETCD_NAME is the server short hostname.
+
+Logs are available at /var/log/etcd-service.log
+
+```yaml
+k3os:
+  etcd:
+     iface: eth1
+     token: "etcdsecret"
+     args:
+      - "--name=${ETCD_NAME}"
+      - "--data-dir=/var/lib/etcd-data"
+      - "--initial-advertise-peer-urls=http://${ETCD_HOST_IP}:2380"
+      - "--listen-peer-urls=http://${ETCD_HOST_IP}:2380"
+      - "--listen-client-urls=http://${ETCD_HOST_IP}:2379,http://127.0.0.1:2379"
+      - "--advertise-client-urls=http://${ETCD_HOST_IP}:2379"
+      - "--initial-cluster-token=${ETCD_TOKEN}"
+      - "--initial-cluster=${ETCD_NAME}=http://${ETCD_HOST_IP}:2380"
+      - "--initial-cluster-state=new"
 
 ## License
 Copyright (c) 2014-2020 [Rancher Labs, Inc.](http://rancher.com)

--- a/images/20-progs/Dockerfile
+++ b/images/20-progs/Dockerfile
@@ -26,3 +26,17 @@ COPY --from=k3os /output/ /output/
 WORKDIR /output
 RUN git clone --branch v0.7.0 https://github.com/ahmetb/kubectx.git \
  && chmod -v +x kubectx/kubectx kubectx/kubens
+# ETCD
+# AMD64 and ARM64 is supported, otherwise etcd is disabled
+ARG ARCH
+ENV ETCD_VER v3.4.7
+ENV ETCD_DOWNLOAD_URL https://github.com/etcd-io/etcd/releases/download
+RUN mkdir etcd
+RUN if [ "$ARCH" == "amd64" ] || [ "$ARCH" == "arm64" ]; then \
+      apk -U add curl; \
+      curl -L ${ETCD_DOWNLOAD_URL}/${ETCD_VER}/etcd-${ETCD_VER}-linux-${ARCH}.tar.gz -o ${ETCD_VER}-linux-${ARCH}.tar.gz; \
+      tar xzvf ${ETCD_VER}-linux-${ARCH}.tar.gz --strip-components=1 -C etcd; \
+      rm -f ${ETCD_VER}-linux-${ARCH}.tar.gz; \
+    else \
+      touch etcd/etcd.disabled; \
+    fi

--- a/images/20-rootfs/Dockerfile
+++ b/images/20-rootfs/Dockerfile
@@ -83,6 +83,8 @@ COPY --from=k3s /output/install.sh /usr/src/image/libexec/k3os/k3s-install.sh
 COPY --from=progs /output/metadata /usr/src/image/sbin/metadata
 COPY --from=progs /output/kubectx/kubectx /output/kubectx/kubens /usr/src/image/bin/
 
+COPY --from=progs /output/etcd/* /usr/src/image/sbin
+
 COPY overlay/ /usr/src/image/
 
 RUN ln -s /k3os/system/k3os/current/k3os /usr/src/image/sbin/k3os

--- a/overlay/etc/init.d/etcd-service
+++ b/overlay/etc/init.d/etcd-service
@@ -1,0 +1,26 @@
+#!/sbin/openrc-run
+
+depend() {
+    after network-online
+    want cgroups
+}
+
+start_pre() {
+    mkdir -p /var/lib/etcd-data/
+}
+
+supervisor=supervise-daemon
+name=etcd-service
+command="/sbin/etcd"
+command_args=" $ETCD_ARGS
+    >>/var/log/etcd-service.log 2>&1"
+
+output_log=/var/log/etcd-service.log
+error_log=/var/log/etcd-service.log
+
+pidfile="/var/run/etcd-service.pid"
+respawn_delay=5
+
+set -o allexport
+if [ -f /etc/environment ]; then source /etc/environment; fi
+set +o allexport

--- a/pkg/cc/apply.go
+++ b/pkg/cc/apply.go
@@ -32,6 +32,7 @@ func RunApply(cfg *config.CloudConfig) error {
 		ApplyRuncmd,
 		ApplyInstall,
 		ApplyK3SInstall,
+		ApplyEtcd,
 	)
 }
 

--- a/pkg/cc/funcs.go
+++ b/pkg/cc/funcs.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -317,6 +318,95 @@ func ApplyEnvironment(cfg *config.CloudConfig) error {
 	if err := ioutil.WriteFile("/etc/environment", buf.Bytes(), 0644); err != nil {
 		return fmt.Errorf("failed to write to /etc/environment: %v", err)
 	}
+
+	return nil
+}
+
+// ApplyEtcd etcd configuration
+func ApplyEtcd(cfg *config.CloudConfig) error {
+
+	iface := cfg.K3OS.Etcd.Iface
+	token := cfg.K3OS.Etcd.Token
+	args := cfg.K3OS.Etcd.Args
+
+	missingConfig := false
+
+	if len(iface) == 0 {
+		missingConfig = true
+	}
+
+	if len(token) == 0 {
+		missingConfig = true
+	}
+
+	if len(args) == 0 {
+		missingConfig = true
+	}
+
+	if missingConfig {
+
+		// Etcd Configuration is missing, ensure that the service is stopped and run level
+		// scripts are removed
+
+		// Get the etcd-service status if it is running
+		cmd := exec.Command("/etc/init.d/etcd-service", "status")
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stdin = os.Stdin
+		cmd.Run()
+
+		started, _ := regexp.Match(`started`, out.Bytes())
+
+		if started {
+			// Stop the etcd service
+			cmd = exec.Command("/etc/init.d/etcd-service", "stop")
+			cmd.Stderr = os.Stderr
+			cmd.Stdout = os.Stdout
+			cmd.Stdin = os.Stdin
+			cmd.Run()
+		}
+
+		// Remove the etcd service from the run level
+		cmd = exec.Command("/usr/sbin/rc-update", "-qq", "del", "etcd-service")
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		cmd.Stdin = os.Stdin
+		cmd.Run()
+
+		return nil
+	}
+
+	// Etcd Configuration
+
+	// Write out the configuration file
+	configFile := "/etc/conf.d/etcd-service"
+	buf := &bytes.Buffer{}
+	buf.WriteString("rc_need=\"!net !net-online\"\nrc_after=\"ccapply\"\nrc_want=\"network-online\"\n")
+	buf.WriteString("ETCD_IFACE=\"" + iface + "\"\n")
+	buf.WriteString("ETCD_HOST_IP=\"$(ip addr show $ETCD_IFACE | grep \"inet\\b\" | awk '{print $2}' | cut -d/ -f1)\"\n")
+	buf.WriteString("ETCD_NAME=\"$(hostname -s)\"\n")
+	buf.WriteString("ETCD_TOKEN=\"" + token + "\"\n")
+	buf.WriteString("ETCD_ARGS=\"" + strings.Join(args, " ") + "\"\n")
+	err := ioutil.WriteFile(configFile, buf.Bytes(), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write "+configFile+": %v", err)
+	}
+
+	// Add the etcd service to the default run level
+	cmd := exec.Command("/usr/sbin/rc-update", "add", "etcd-service")
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Run()
+
+	// Start the etcd service
+	cmd = exec.Command("/etc/init.d/etcd-service", "start")
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Run()
 
 	return nil
 }

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -61,6 +61,7 @@ func Command() cli.Command {
 			}
 			return nil
 		},
+
 		Action: func(*cli.Context) {
 			if err := Main(); err != nil {
 				logrus.Error(err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ type K3OS struct {
 	Environment    map[string]string `json:"environment,omitempty"`
 	Taints         []string          `json:"taints,omitempty"`
 	Install        *Install          `json:"install,omitempty"`
+	Etcd           Etcd              `json:"etcd,omitempty"`
 }
 
 type Wifi struct {
@@ -38,6 +39,12 @@ type Install struct {
 	NoFormat  bool   `json:"noFormat,omitempty"`
 	Debug     bool   `json:"debug,omitempty"`
 	TTY       string `json:"tty,omitempty"`
+}
+
+type Etcd struct {
+	Iface string   `json:"iface,omitempty"`
+	Token string   `json:"token,omitempty"`
+	Args  []string `json:"args,omitempty"`
 }
 
 type CloudConfig struct {


### PR DESCRIPTION
This pull request adds the etcd service configured via cloud config and has been tested with a multi node etcd setup, allowing for a k3s to use as a storage backend.