### PR TITLE
Fix /usr/libexec/kubernetes by symlinking to /var/lib/rancher/k3s/agent/libexec/kubernetes

### DIFF
--- a/images/20-rootfs/Dockerfile
+++ b/images/20-rootfs/Dockerfile
@@ -53,6 +53,10 @@ RUN rm -rf \
 RUN rm -rf /usr/src/image/local \
  && ln -s /var/local /usr/src/image/local
 
+# setup /usr/libexec/kubernetes
+RUN rm -rf /usr/libexec/kubernetes \
+ && ln -s /var/lib/rancher/k3s/agent/libexec/kubernetes /usr/src/image/libexec/kubernetes
+
 # cleanup files hostname/hosts
 RUN rm -rf \
     /usr/src/image/etc/hosts \

--- a/overlay/libexec/k3os/boot
+++ b/overlay/libexec/k3os/boot
@@ -152,6 +152,11 @@ setup_manifests()
     rsync -a --exclude='*.example' /usr/share/rancher/k3s/server/manifests/ /var/lib/rancher/k3s/server/manifests/
 }
 
+setup_agent_libexec()
+{
+    mkdir -p /var/lib/rancher/k3s/agent/libexec/kubernetes
+}
+
 do_grow_live()
 {
     parted $1 resizepart $2 yes 100%
@@ -197,4 +202,5 @@ setup_sudoers
 setup_services
 setup_config
 setup_manifests
+setup_agent_libexec
 cleanup


### PR DESCRIPTION
As discussed in #282.

Should it maybe be synlinked to `/var/libexec/kubernetes`?

Also, I haven't tested this at all.