### PR TITLE
kernel: 5.0.0-47.51-rancher1

### DIFF
--- a/images/10-kernel-stage1/Dockerfile
+++ b/images/10-kernel-stage1/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get --assume-yes update \
  && echo 'nls_iso8859_1' >> /etc/initramfs-tools/modules
 
 ARG ARCH
-ENV KVERSION=5.0.0-43-generic
-ENV URL=https://github.com/rancher/k3os-kernel/releases/download/5.0.0-43.47-rancher1
+ENV KVERSION=5.0.0-47-generic
+ENV URL=https://github.com/rancher/k3os-kernel/releases/download/5.0.0-47.51-rancher1
 ENV KERNEL_XZ=${URL}/kernel-generic_${ARCH}.tar.xz
 ENV KERNEL_EXTRA_XZ=${URL}/kernel-extra-generic_${ARCH}.tar.xz
 ENV KERNEL_HEADERS_XZ=${URL}/kernel-headers-generic_${ARCH}.tar.xz


### PR DESCRIPTION
From [github-releases://rancher/k3os-kernel#5.0.0-47.51-rancher1](https://github.com/rancher/k3os-kernel/releases/tag/5.0.0-47.51-rancher1)
- Ubuntu Bionic/HWE 5.0.0-47.51~18.04.1
- Linux Firmware 1.173.18
- Wireguard 1.0.20200413 (h/t @hughobrien and @dclark)

Fixes #469