### PR TITLE
Fix takeover on Ubuntu

### DIFF
--- a/overlay/libexec/k3os/mode-disk
+++ b/overlay/libexec/k3os/mode-disk
@@ -111,6 +111,10 @@ takeover()
 
     touch k3os/system/factory-reset
 
+    if [ -L sbin ]; then
+      rm -f sbin
+    fi
+
     for i in *; do
         case $i in
             boot|k3os|sbin)


### PR DESCRIPTION
Handles case where /sbin is a symlink to /usr/sbin

Current state fails later on `mkdir -p $TARGET/usr/sbin` - it already exists but is a broken symlink.