### PR TITLE
TTY config fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -185,7 +185,7 @@ EOF
     else
         TTY=$K3OS_INSTALL_TTY
     fi
-    if [ -e "/dev/$TTY" ] && [ "$TTY" != tty1 ] && [ -n "$TTY" ]; then
+    if [ -e "/dev/${TTY%,*}" ] && [ "$TTY" != tty1 ] && [ -n "$TTY" ]; then
         sed -i "s!console=tty1!console=tty1 console=${TTY}!g" ${TARGET}/boot/grub/grub.cfg
     fi
 

--- a/overlay/libexec/k3os/boot
+++ b/overlay/libexec/k3os/boot
@@ -15,9 +15,10 @@ setup_ttys()
             MODE=shell
             ;;
         console=*)
-            TTY=${x#console=}
+            CONSOLE_SPEC=${x#console=}
+            IFS=, read TTY BAUDRATE _ <<<"${CONSOLE_SPEC},9600"
             if [ -e /dev/${TTY} ] && ! grep -q "^${TTY}::" /etc/inittab; then
-                echo "${TTY}::respawn:/sbin/getty -L ttyS0 115200 vt100" >> /etc/inittab
+                echo "${TTY}::respawn:/sbin/getty -L ${BAUDRATE} ${TTY} vt100" >> /etc/inittab
                 echo ${TTY} >> /etc/securetty
             fi
             ;;


### PR DESCRIPTION
* pass correct TTY to getty for serial console
* support specifying baud rate as part of console kernel argument
* default baudrate to 9600 to align with kernel default

Fixes #492 