### PR TITLE
k3s: v1.17.6+k3s1

### DIFF
--- a/images/10-k3s/Dockerfile
+++ b/images/10-k3s/Dockerfile
@@ -4,7 +4,7 @@ FROM ${REPO}/k3os-base:${TAG}
 
 ARG ARCH
 ENV ARCH ${ARCH}
-ENV VERSION v1.17.5+k3s1
+ENV VERSION v1.17.6+k3s1
 ADD https://raw.githubusercontent.com/rancher/k3s/${VERSION}/install.sh /output/install.sh
 ENV INSTALL_K3S_VERSION=${VERSION} \
     INSTALL_K3S_SKIP_START=true \


### PR DESCRIPTION
- CVE-2020-10749 - IPv4 only clusters susceptible to MitM attacks via IPv6 rogue router advertisements
- CVE-2020-8555 - kube-controller-manager SSRF