### PR TITLE
Added a Grub option for moving straight to install

### DIFF
--- a/images/70-iso/grub.cfg
+++ b/images/70-iso/grub.cfg
@@ -15,6 +15,15 @@ menuentry "k3OS LiveCD & Installer" {
   initrd /k3os/system/kernel/current/initrd
 }
 
+menuentry "k3OS Installer" {
+  search.fs_label K3OS root
+  set sqfile=/k3os/system/kernel/current/kernel.squashfs
+  loopback loop0 /$sqfile
+  set root=($root)
+  linux (loop0)/vmlinuz printk.devkmsg=on k3os.mode=install console=ttyS0 console=tty1
+  initrd /k3os/system/kernel/current/initrd
+}
+
 menuentry "k3OS Rescue Shell" {
   search.fs_label K3OS root
   set sqfile=/k3os/system/kernel/current/kernel.squashfs


### PR DESCRIPTION
Added a Grub option for starting the installer so a user does not need to login as `rancher` user and run `sudo k3os install`.
I've tested the Grub option manually with an existing ISO but haven't built my own ISO to verify but it seems low-risk.

This solves https://github.com/rancher/k3os/issues/499