### PR TITLE
Wait 30 seconds before failing to determine mode

### DIFF
--- a/overlay/libexec/k3os/mode
+++ b/overlay/libexec/k3os/mode
@@ -16,6 +16,10 @@ for x in $(cat /proc/cmdline); do
     esac
 done
 
+MODE_WAIT_SECONDS=30
+
+while [ -z "$MODE" ] && (( MODE_WAIT_SECONDS > 0 )); do
+
 if [ -z "$MODE" ] && [ -n "$(blkid -L K3OS_STATE)" ]; then
     MODE=disk
 fi
@@ -31,6 +35,13 @@ fi
 if [ -z "$MODE" ] && [ "$(stat -f -c '%T' /)" != "tmpfs" ]; then
     MODE=local
 fi
+
+if [ -z "$MODE" ]; then
+  echo "Couldn't determine boot mode, waiting $MODE_WAIT_SECONDS seconds..."
+  sleep 1
+  MODE_WAIT_SECONDS=$((MODE_WAIT_SECONDS - 1))
+fi
+done
 
 if [ -z "$MODE" ]; then
     pfatal Failed to determine boot mode


### PR DESCRIPTION
I haven't been able to test this, but I believe this would fix #376, #458, and #462. See https://github.com/rancher/k3os/issues/376#issuecomment-641139116