### PR TITLE
Make "Failed to determine boot mode" a little more user friendly

### DIFF
--- a/overlay/libexec/k3os/mode
+++ b/overlay/libexec/k3os/mode
@@ -33,7 +33,7 @@ if [ -z "$MODE" ] && [ "$(stat -f -c '%T' /)" != "tmpfs" ]; then
 fi
 
 if [ -z "$MODE" ]; then
-    pfatal Failed to determine boot mode
+    pfatal "Failed to determine boot mode (did you forget to set k3os.mode?)"
 elif [ ! -e $SCRIPTS/mode-${MODE} ]; then
     pfatal "Mode script does not exist for ${MODE}"
 else


### PR DESCRIPTION
This is likely a common error as it's the first error people encounter when forgetting to set up any cmdline.