### PR TITLE
cli: fix typo of "separated" in install

### DIFF
--- a/pkg/cliinstall/ask.go
+++ b/pkg/cliinstall/ask.go
@@ -272,7 +272,7 @@ func AskGithub(cfg *config.CloudConfig) error {
 		return err
 	}
 
-	str, err := questions.Prompt("Comma seperated list of GitHub users to authorize: ", "")
+	str, err := questions.Prompt("Comma separated list of GitHub users to authorize: ", "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #474
Supersedes #473