### PR TITLE
run grub-install with `--removable` to install grub efi binary to efi…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -210,7 +210,7 @@ EOF
         GRUB_TARGET="--target=x86_64-efi"
     fi
 
-    grub-install ${GRUB_TARGET} --boot-directory=${TARGET}/boot ${DEVICE}
+    grub-install ${GRUB_TARGET} --boot-directory=${TARGET}/boot --removable ${DEVICE}
 }
 
 get_iso()


### PR DESCRIPTION
… fallback location

- installs grub's efi binary into `EFI/BOOT/BOOTX64.EFI`
- this fixes booting in bhyve but should be tested on other platforms!

From Arch Wiki:
> Some UEFI firmwares require a bootable file at a known location before they will show UEFI NVRAM boot entries. If this is the case, grub-install will claim efibootmgr has added an entry to boot GRUB, however the entry will not show up in the VisualBIOS boot order selector. The solution is to install GRUB at the default/fallback boot path:
> *grub-install --target=x86_64-efi --efi-directory=esp **--removable***

Links:
- https://wiki.archlinux.org/index.php/GRUB#Default/fallback_boot_path
- https://www.jongibbins.com/solving-uefi-boot-problems-on-bhyve-freenas-vm/