### PR TITLE
mount from bare usb device if mount fails

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ cleanup2()
         umount ${TARGET} || true
     fi
 
-    losetup -d ${ISO_DEVICE} || true
+    losetup -d ${ISO_DEVICE} || losetup -d ${ISO_DEVICE%?} || true
     umount $DISTRO || true
 }
 
@@ -116,8 +116,8 @@ do_mount()
         mount ${BOOT} ${TARGET}/boot/efi
     fi
 
-    mkdir -p $DISTRO
-    mount -o ro $ISO_DEVICE $DISTRO
+    mkdir -p ${DISTRO}
+    mount -o ro ${ISO_DEVICE} ${DISTRO} || mount -o ro ${ISO_DEVICE%?} ${DISTRO}
 }
 
 do_copy()


### PR DESCRIPTION
If mounting the discovered USB device fails during install, try again mounting the bare device, i.e. /dev/sdb3 -> /dev/sdb.

Fixes #527 