### PR TITLE
Added service for ensuring system clock is plausibly set

### DIFF
--- a/overlay/etc/conf.d/clock-sane
+++ b/overlay/etc/conf.d/clock-sane
@@ -1,0 +1,10 @@
+# The minimum acceptable UNIX timestamp to presume the clock is set to
+# a sane value. The default is the UNIX timestamp for the first second
+# of the year 1980 UTC (matching the validation by k3s)
+#min_timestamp=315532800
+
+# The timeout setting controls how long the clock-sane service waits
+# for the system clock to be set to the minimum acceptable date.
+# The default is 120 seconds.
+# if this is set to 0, the wait is infinite.
+timeout=0

--- a/overlay/etc/conf.d/k3s-service
+++ b/overlay/etc/conf.d/k3s-service
@@ -1,3 +1,3 @@
 rc_need="!net !net-online"
 rc_after="ccapply"
-rc_want="network-online"
+rc_want="clock-sane network-online"

--- a/overlay/etc/init.d/clock-sane
+++ b/overlay/etc/init.d/clock-sane
@@ -1,0 +1,31 @@
+#!/sbin/openrc-run
+
+description="Delays until the system time is set to a plausible time"
+
+depend()
+{
+	provide clock-sane
+	keyword -timeout -shutdown
+}
+
+start()
+{
+	local infinite now rc
+	
+	min_timestamp=${min_timestamp:-315532800}
+	timeout=${timeout:-120}
+	
+	ebegin "Checking to see if the system clock is plausibly set"
+	rc=0
+	[ $timeout -eq 0 ] && infinite=true || infinite=false
+	
+	while $infinite || [ $timeout -gt 0 ]; do
+		now=$(date '+%s')
+		[ "${now}" -gt ${min_timestamp} ] || [ "${now}" -eq ${min_timestamp} ] && break
+		sleep 1
+		: $((timeout -= 1))
+	done
+	! $infinite && [ $timeout -eq 0 ] && rc=1
+	
+	eend $rc "The system clock is not plausibly set"
+}

--- a/overlay/libexec/k3os/boot
+++ b/overlay/libexec/k3os/boot
@@ -38,11 +38,11 @@ setup_services()
         ln -s /etc/init.d/$i /etc/runlevels/sysinit
     done
 
-    for i in acpid hwclock syslog bootmisc hostname sysctl modules connman dbus haveged issue; do
+    for i in acpid hwclock syslog bootmisc hostname sysctl modules connman dbus haveged issue sshd; do
         ln -s /etc/init.d/$i /etc/runlevels/boot
     done
 
-    for i in sshd "local" ccapply iscsid; do
+    for i in "local" ccapply iscsid; do
         ln -s /etc/init.d/$i /etc/runlevels/default
     done
 


### PR DESCRIPTION
### Background

I'm using two Raspberry Pis at home running k3os as single node clusters and ran into the following issue:

 * The lack of a hardware clock means the Raspberry Pi relies entirely on an NTP server at boot to set the system clock
 * k3s is [hard-coded to fail to start](https://github.com/rancher/k3s/blob/66a8c2ad7f0f9b87377aeb06201d1dab3007fdde/pkg/cli/cmds/log.go#L82) if the system time is set before 1980
 * There's no mechanism currently in k3os to wait for the clock to be validly set before starting k3s
 * After failing to start k3s some amount of times, it will no longer be retried

This means if, for whatever reason, the Pi is unable to update its system time quickly enough via NTP, it can go into a state that requires administrator intervention to recover.

In my case, these Pis are serving as the DNS servers for my network, so it's important to me that they are sufficiently robust that they will begin running Kubernetes soon after (e.g.) a network-wide power outage is restored. They're configured to sync time with a public NTP server, but my cable modem can sometimes take a few minutes to initialize Internet connectivity. The net result is that their clocks don't get synced for a few minutes when starting up, but by then k3s has failed to start enough times that it's no longer being retried.

### TL;DR

I created this pull request to cause k3os to wait until the system time is set to 1980 or later before starting k3s. This based on the idea that there's no plausible circumstance under which one would want k3s to start without that happening, since it will definitively fail due to the hard-coded check.

### Details

This should have no noticeable effect on any system with a functioning / set hardware clock.

I did set a configurable timeout for it in `/etc/conf.d/clock-sane`, although it is set to 0 (wait forever) by default.

The only other change here is to move sshd to the `boot` runlevel (instead of `default`). This was done to ensure sshd isn't delayed in coming up as a result of waiting for the system time to be set. 