### PR TITLE
k3s: avoid over-quoting install envvars

### DIFF
--- a/pkg/cc/funcs.go
+++ b/pkg/cc/funcs.go
@@ -122,16 +122,16 @@ func ApplyK3S(cfg *config.CloudConfig, restart, install bool) error {
 			args = append(args, "server")
 		}
 	} else {
-		vars = append(vars, fmt.Sprintf("K3S_URL=\"%s\"\n", cfg.K3OS.ServerURL))
+		vars = append(vars, fmt.Sprintf("K3S_URL=%s", cfg.K3OS.ServerURL))
 		if len(args) == 0 {
 			args = append(args, "agent")
 		}
 	}
 
 	if strings.HasPrefix(cfg.K3OS.Token, "K10") {
-		vars = append(vars, fmt.Sprintf("K3S_TOKEN=\"%s\"\n", cfg.K3OS.Token))
+		vars = append(vars, fmt.Sprintf("K3S_TOKEN=%s", cfg.K3OS.Token))
 	} else if cfg.K3OS.Token != "" {
-		vars = append(vars, fmt.Sprintf("K3S_CLUSTER_SECRET=\"%s\"\n", cfg.K3OS.Token))
+		vars = append(vars, fmt.Sprintf("K3S_CLUSTER_SECRET=%s", cfg.K3OS.Token))
 	}
 
 	var labels []string


### PR DESCRIPTION
Fix K3S_URL, K3S_TOKEN, and K3S_CLUSTER_SECRET being passed to k3s
install.sh with extra quotes around the values. Rely on k3s install.sh
to correctly capture entries for `/etc/rancher/k3s/k3s-service.env`.

Fixes #589
