### PR TITLE
Install wpa_supplicant explicitly

### DIFF
--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -56,6 +56,7 @@ RUN apk --no-cache add \
     util-linux \
     vim \
     wireguard-tools \
+    wpa_supplicant \
     xz \
  && mv -vf /etc/conf.d/qemu-guest-agent /etc/conf.d/qemu-guest-agent.orig \
  && mv -vf /etc/conf.d/rngd             /etc/conf.d/rngd.orig \


### PR DESCRIPTION
Previously, wpa_supplicant was install implicitly as a dependency of connman. In alpine 3.12 it is no longer a depedency and needs to be added seperately.

Fixes #593 