### PR TITLE
New instructions how to enable auto-upgrade V11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ the cluster.
 
 Integration with [rancher/system-upgrade-controller](https://github.com/rancher/system-upgrade-controller) has been implemented as of [v0.9.0](https://github.com/rancher/k3os/releases/tag/v0.9.0).
 To enable a k3OS node to automatically upgrade from the [latest GitHub release](https://github.com/rancher/k3os/releases/latest) you will need to make sure it has the label 
-`k3os.io/upgrade` with a value `enabled` (and for versions prior to v11.x, please use label `plan.upgrade.cattle.io/k3os-latest` with a value anything other than `disabled`). The upgrade controller will then spawn an upgrade job
+`k3os.io/upgrade` with value `enabled` (for k3OS versions prior to v0.11.x please use label `plan.upgrade.cattle.io/k3os-latest`). The upgrade controller will then spawn an upgrade job
 that will drain most pods, upgrade the k3OS content under `/k3os/system`, and then reboot. The system should come back up running the latest
 kernel and k3s version bundled with k3OS and ready to schedule pods.
 

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ the cluster.
 
 Integration with [rancher/system-upgrade-controller](https://github.com/rancher/system-upgrade-controller) has been implemented as of [v0.9.0](https://github.com/rancher/k3os/releases/tag/v0.9.0).
 To enable a k3OS node to automatically upgrade from the [latest GitHub release](https://github.com/rancher/k3os/releases/latest) you will need to make sure it has the label 
-`plan.upgrade.cattle.io/k3os-latest` with a value anything other than `disabled`. The upgrade controller will then spawn an upgrade job
+`k3os.io/upgrade` with a value `enabled` (and for versions prior to v11.x, please use label `plan.upgrade.cattle.io/k3os-latest` with a value anything other than `disabled`). The upgrade controller will then spawn an upgrade job
 that will drain most pods, upgrade the k3OS content under `/k3os/system`, and then reboot. The system should come back up running the latest
 kernel and k3s version bundled with k3OS and ready to schedule pods.
 


### PR DESCRIPTION
As stated in this issue: https://github.com/rancher/k3os/issues/556, users need to apply a diff label to enable auto upgrades on v11+.