### PR TITLE
feat: Allow netbooting using r8152 based USB Ethernet adapter

### DIFF
--- a/images/10-kernel-stage1/Dockerfile
+++ b/images/10-kernel-stage1/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get --assume-yes update \
     lz4 \
     rsync \
     xz-utils \
+ && echo 'r8152' >> /etc/initramfs-tools/modules \
  && echo 'hfs' >> /etc/initramfs-tools/modules \
  && echo 'hfsplus' >> /etc/initramfs-tools/modules \
  && echo 'nls_utf8' >> /etc/initramfs-tools/modules \


### PR DESCRIPTION
Add r8152 module to initramfs to enable netboot from r8152 based USB Ethernet adapter.

This PR can be extended to include more USB Ethernet devices if needed.