### PR TITLE
Spelling of behaviour is now consistent

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,12 +20,12 @@ assignees: ''
 <!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
-<!-- Steps to reproduce the behavior: -->
+<!-- Steps to reproduce the behaviour: -->
 
-**Expected behavior**
+**Expected behaviour**
 <!-- A clear and concise description of what you expected to happen. -->
 
-**Actual behavior**
+**Actual behaviour**
 <!-- A clear and concise description of what actually happened. -->
 
 **Additional context**


### PR DESCRIPTION
I noticed behaviour was spelt differently a couple of times in the bug report template.

It ain't much, but it's honest work.