### PR TITLE
Updated config with packer fix for version 1.6.5

### DIFF
--- a/package/packer/vsphere/server/k3os-server.json
+++ b/package/packer/vsphere/server/k3os-server.json
@@ -1,67 +1,75 @@
 {
-  "builders": [{
-    "type": "vsphere-iso",
-    "vcenter_server": "{{user `vcenter_server`}}",
-    "username": "{{user `vcenter_username`}}",
-    "password": "{{user `vcenter_password`}}",
-    "insecure_connection": "true",
-
-    "vm_name": "{{user `template_name`}}",
-    "datastore": "{{user `vcenter_datastore`}}",
-    "folder": "{{user `vcenter_folder`}}",
-    "host":     "{{user `vcenter_host`}}",
-    "network": "{{user `vcenter_network`}}",
-    "boot_order": "disk,cdrom",
-    "convert_to_template": "true",
-
-    "guest_os_type": "other4xLinux64Guest",
-
-    "CPUs":             2,
-    "RAM":              2048,
-    "RAM_reserve_all": true,
-
-    "disk_controller_type":  "pvscsi",
-    "disk_size":        10240,
-    "disk_thin_provisioned": true,
-
-    "network_card": "vmxnet3",
-
-    "iso_paths": [ "{{user `vcenter_iso_path`}}"],
-    "ssh_username": "{{user `ssh_username`}}",
-    "ssh_password": "{{user `rancher_password`}}",
-
-    "boot_wait": "30s",
-    "boot_command": [
-      "rancher",
-      "<enter>",
-      "sudo k3os install",
-      "<enter>",
-      "1",
-      "<enter>",
-      "N",
-      "<enter>",
-      "N",
-      "<enter>",
-      "{{user `rancher_password`}}",
-      "<enter>",
-      "{{user `rancher_password`}}",
-      "<enter>",
-      "N",
-      "<enter>",
-      "1",
-      "<enter>",
-      "{{user `server_token`}}",
-      "<enter>",
-      "Y",
-      "<enter>"
-    ],
-    "shutdown_command": "sudo poweroff"
-  }],
-  "provisioners":[
+  "builders": [
     {
-      "type": "shell",
+      "CPUs": 2,
+      "RAM": 2048,
+      "RAM_reserve_all": true,
+      "boot_command": [
+        "rancher",
+        "<enter>",
+        "sudo k3os install",
+        "<enter>",
+        "1",
+        "<enter>",
+        "N",
+        "<enter>",
+        "N",
+        "<enter>",
+        "{{user `rancher_password`}}",
+        "<enter>",
+        "{{user `rancher_password`}}",
+        "<enter>",
+        "N",
+        "<enter>",
+        "1",
+        "<enter>",
+        "{{user `server_token`}}",
+        "<enter>",
+        "Y",
+        "<enter>"
+      ],
+      "boot_order": "disk,cdrom",
+      "boot_wait": "40s",
+      "convert_to_template": "true",
+      "datastore": "{{user `vcenter_datastore`}}",
+      "disk_controller_type": "pvscsi",
+      "folder": "{{user `vcenter_folder`}}",
+      "guest_os_type": "other4xLinux64Guest",
+      "host": "{{user `vcenter_host`}}",
+      "insecure_connection": "true",
+      "iso_paths": [
+        "{{user `vcenter_iso_path`}}"
+      ],
+      "network_adapters": [
+        {
+          "network": "{{user `vcenter_network`}}",
+          "network_card": "vmxnet3"
+        }
+      ],
+      "password": "{{user `vcenter_password`}}",
+      "shutdown_command": "sudo poweroff",
+      "ssh_password": "{{user `rancher_password`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "storage": [
+        {
+          "disk_size": 10240,
+          "disk_thin_provisioned": true
+        }
+      ],
+      "type": "vsphere-iso",
+      "username": "{{user `vcenter_username`}}",
+      "vcenter_server": "{{user `vcenter_server`}}",
+      "vm_name": "{{user `template_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
       "execute_command": "{{ .Vars }} sudo -E sh '{{ .Path }}'",
-      "inline": ["echo hello world"]
+      "inline": [
+        "echo hello world"
+      ],
+      "type": "shell"
     }
   ]
 }
+


### PR DESCRIPTION
There is a breaking change in packer, storage is now a separate subobject. 
This is the result of running the "fix" within Packer itself that converts the old format to the new format.