### PR TITLE
Bump kernel Focal 5.4.0-58.64

### DIFF
--- a/images/10-k3s/Dockerfile
+++ b/images/10-k3s/Dockerfile
@@ -4,7 +4,7 @@ FROM ${REPO}/k3os-base:${TAG}
 
 ARG ARCH
 ENV ARCH ${ARCH}
-ENV VERSION v1.19.4+k3s1
+ENV VERSION v1.19.5+k3s2
 ADD https://raw.githubusercontent.com/rancher/k3s/${VERSION}/install.sh /output/install.sh
 ENV INSTALL_K3S_VERSION=${VERSION} \
     INSTALL_K3S_SKIP_START=true \

--- a/images/10-k3s/Dockerfile
+++ b/images/10-k3s/Dockerfile
@@ -4,7 +4,7 @@ FROM ${REPO}/k3os-base:${TAG}
 
 ARG ARCH
 ENV ARCH ${ARCH}
-ENV VERSION v1.19.5+k3s2
+ENV VERSION v1.19.4+k3s1
 ADD https://raw.githubusercontent.com/rancher/k3s/${VERSION}/install.sh /output/install.sh
 ENV INSTALL_K3S_VERSION=${VERSION} \
     INSTALL_K3S_SKIP_START=true \

--- a/images/10-kernel-stage1/Dockerfile
+++ b/images/10-kernel-stage1/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get --assume-yes update \
  && echo 'nls_iso8859_1' >> /etc/initramfs-tools/modules
 
 ARG ARCH
-ENV KVERSION=5.4.0-54-generic
-ENV URL=https://github.com/rancher/k3os-kernel/releases/download/5.4.0-54.60-rancher1
+ENV KVERSION=5.4.0-58-generic
+ENV URL=https://github.com/rancher/k3os-kernel/releases/download/5.4.0-58.64-rancher1
 ENV KERNEL_XZ=${URL}/kernel-generic_${ARCH}.tar.xz
 ENV KERNEL_EXTRA_XZ=${URL}/kernel-extra-generic_${ARCH}.tar.xz
 ENV KERNEL_HEADERS_XZ=${URL}/kernel-headers-generic_${ARCH}.tar.xz


### PR DESCRIPTION
k3os-kernel portion of the work is here:
https://github.com/rancher/k3os-kernel/pull/29

The kernel artifact would have to be uploaded before merging this PR.