### PR TITLE
Set AWS Packer region using AWS_DEFAULT_REGION

### DIFF
--- a/package/packer/aws/template-arm64.json
+++ b/package/packer/aws/template-arm64.json
@@ -57,7 +57,7 @@
     "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "iso_url": "https://github.com/rancher/k3os/releases/download/v0.11.0/k3os-arm64.iso",
     "k3os_version": "v0.11.0",
-    "region": "us-east-1"
+    "region": "{{env `AWS_DEFAULT_REGION`}}"
   }
 }
 

--- a/package/packer/aws/template.json
+++ b/package/packer/aws/template.json
@@ -57,7 +57,7 @@
     "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "iso_url": "https://github.com/rancher/k3os/releases/download/v0.11.0/k3os-amd64.iso",
     "k3os_version": "v0.11.0",
-    "region": "us-east-1"
+    "region": "{{env `AWS_DEFAULT_REGION`}}"
   }
 }
 


### PR DESCRIPTION
Fixes #117 

Currently `us-east-1` is hard coded as a variable, but the official Packer instructions in https://github.com/rancher/k3os/blob/master/package/packer/aws/README.md#setup instruct the user to set AWS_DEFAULT_REGION