### PR TITLE
Initial support for rootless mode

### DIFF
--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -50,6 +50,7 @@ RUN apk --no-cache add \
     qemu-guest-agent \
     rng-tools \
     rsync \
+    shadow-uidmap \
     strace \
     sudo \
     tar \

--- a/overlay/libexec/k3os/bootstrap
+++ b/overlay/libexec/k3os/bootstrap
@@ -28,6 +28,8 @@ setup_users()
     addgroup -g 1000 rancher
     adduser -s /bin/bash -u 1000 -D -G rancher rancher
     echo 'rancher:*' | chpasswd -e
+    echo "rancher:231072:65536" > /etc/subuid
+    echo "rancher:231072:65536" > /etc/subgid
 }
 
 setup_dirs()

--- a/pkg/cc/funcs.go
+++ b/pkg/cc/funcs.go
@@ -152,6 +152,12 @@ func ApplyK3S(cfg *config.CloudConfig, restart, install bool) error {
 		args = append(args, "--kubelet-arg", "register-with-taints="+taint)
 	}
 
+	for _, arg := range args {
+		if arg == "--rootless" {
+			vars = append(vars, fmt.Sprintf("INSTALL_K3S_EXEC_USER=%s", "rancher"))
+		}
+	}
+
 	cmd := exec.Command("/usr/libexec/k3os/k3s-install.sh", args...)
 	cmd.Env = append(os.Environ(), vars...)
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
#### Proposed Changes ####
This PR adds initial support for rootless mode to k3OS.

#### Types of Changes ####
Add necessary logic with https://github.com/k3s-io/k3s/pull/2851 to handle k3s server `--rootless` flag correctly and make k3s server running under rancher user.

Note that this PR does not even try yet make rootless mode fully working without those extra configs on cloud init but instead of 
just allow people to start evaluate rootless mode on k3OS.

#### Verification ####
Anyone how it interested to test this one can find my test build from https://github.com/olljanat/k3os/releases/tag/rootless-test and test it with cloud config https://tinyurl.com/y3frsr3t

After successful boot you can check with `ps -Af|grep k3s` command that k3s server is really running on rancher user and that example `kubectl get nodes` command still works.
