### PR TITLE
Add missing open-vm-tools modules

### DIFF
--- a/images/05-base/Dockerfile
+++ b/images/05-base/Dockerfile
@@ -3,4 +3,8 @@ ARG TAG
 FROM ${REPO}/k3os-base:${TAG} AS base
 RUN apk --no-cache add \
     grub-bios \
-    open-vm-tools
+    open-vm-tools \
+    open-vm-tools-deploypkg \
+    open-vm-tools-guestinfo \
+    open-vm-tools-static \
+    open-vm-tools-vmbackup


### PR DESCRIPTION
…in Alpine 3.12 the open-vm-tools package was split into multiple packages. This closes #634 