### PR TITLE
system-upgrade-controller: bump to v0.7.0

### DIFF
--- a/overlay/share/rancher/k3s/server/manifests/system-upgrade-controller.yaml
+++ b/overlay/share/rancher/k3s/server/manifests/system-upgrade-controller.yaml
@@ -67,7 +67,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: system-upgrade-controller
-          image: rancher/system-upgrade-controller:v0.6.2
+          image: rancher/system-upgrade-controller:v0.7.0
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Fixes problem with system-upgrade-controller and FQDN https://github.com/rancher/system-upgrade-controller/issues/110

> 
> Features and Enhancements
>     Bump wrangler to v0.8
>     Support Env and EnvFrom entries on Plans
> Bug Fixes
>     Fix for incorrect job names for nodes with FQDN

Now as a draft as v0.7.0 is a pre-release