### PR TITLE
Add code to increase mlocks (ulimit -l)

### DIFF
--- a/pkg/enterchroot/enter.go
+++ b/pkg/enterchroot/enter.go
@@ -1,6 +1,5 @@
 package enterchroot
 
-
 import (
 	"fmt"
 	"io"
@@ -38,9 +37,9 @@ func Enter() {
 
 	setResourceLimit(unix.RLIMIT_NOFILE, 1048576, 1048576)
 	setResourceLimit(unix.RLIMIT_NPROC, unix.RLIM_INFINITY, unix.RLIM_INFINITY)
-  // Increase mlocks to avoid Go crashes
-  // https://github.com/golang/go/wiki/LinuxKernelSignalVectorBug
-  setResourceLimit(unix.RLIMIT_MEMLOCK, 67108864, 67108864)
+	// Increase mlocks to avoid Go crashes
+	// https://github.com/golang/go/wiki/LinuxKernelSignalVectorBug
+	setResourceLimit(unix.RLIMIT_MEMLOCK, 67108864, 67108864)
 
 	logrus.Debug("Running bootstrap")
 	err := run(os.Getenv("ENTER_DATA"))

--- a/pkg/enterchroot/enter.go
+++ b/pkg/enterchroot/enter.go
@@ -1,5 +1,6 @@
 package enterchroot
 
+
 import (
 	"fmt"
 	"io"
@@ -37,6 +38,9 @@ func Enter() {
 
 	setResourceLimit(unix.RLIMIT_NOFILE, 1048576, 1048576)
 	setResourceLimit(unix.RLIMIT_NPROC, unix.RLIM_INFINITY, unix.RLIM_INFINITY)
+  // Increase mlocks to avoid Go crashes
+  // https://github.com/golang/go/wiki/LinuxKernelSignalVectorBug
+  setResourceLimit(unix.RLIMIT_MEMLOCK, 67108864, 67108864)
 
 	logrus.Debug("Running bootstrap")
 	err := run(os.Getenv("ENTER_DATA"))


### PR DESCRIPTION
This avoid a Go bug which crashes some go processes in Containers

The crashes look like:

I0601 05:18:25.815579       1 main.go:288] Listening securely on :9443
runtime: mlock of signal stack failed: 12
runtime: increase the mlock limit (ulimit -l) or
runtime: update your kernel to 5.3.15+, 5.4.2+, or 5.5+
fatal error: mlock failed

Discussion at: https://github.com/golang/go/wiki/LinuxKernelSignalVectorBug

ulimit -l is changed from 64 to 65536