### PR TITLE
Add control-plane toleration to system-upgrade-controller.

### DIFF
--- a/overlay/share/rancher/k3s/server/manifests/system-upgrade-controller.yaml
+++ b/overlay/share/rancher/k3s/server/manifests/system-upgrade-controller.yaml
@@ -70,7 +70,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: system-upgrade-controller
-          image: rancher/system-upgrade-controller:v0.7.0
+          image: rancher/system-upgrade-controller:v0.7.5
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/overlay/share/rancher/k3s/server/manifests/system-upgrade-controller.yaml
+++ b/overlay/share/rancher/k3s/server/manifests/system-upgrade-controller.yaml
@@ -65,6 +65,9 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
       containers:
         - name: system-upgrade-controller
           image: rancher/system-upgrade-controller:v0.7.0

--- a/overlay/share/rancher/k3s/server/manifests/system-upgrade-plans/k3os-latest.yaml
+++ b/overlay/share/rancher/k3s/server/manifests/system-upgrade-plans/k3os-latest.yaml
@@ -39,6 +39,7 @@ spec:
   tolerations:
     - {key: CriticalAddonsOnly, operator: Exists}
     - {key: node-role.kubernetes.io/master, effect: NoSchedule, operator: Exists}
+    - {key: node-role.kubernetes.io/control-plane, effect: NoSchedule, operator: Exists}
     - {key: kubernetes.io/arch, effect: NoSchedule, operator: Equal, value: amd64}
     - {key: kubernetes.io/arch, effect: NoSchedule, operator: Equal, value: arm64}
     - {key: kubernetes.io/arch, effect: NoSchedule, operator: Equal, value: arm}


### PR DESCRIPTION
# Description

The system upgrade controller manifests only specify a toleration for the deprecated  `node-role.kubernetes.io/control-plane=true:NoSchedule` taint. I run my clusters with the newer `node-role.kubernetes.io/control-plane=true:NoSchedule` taint but I have to manually  patch the system-upgrade-controller manifests for it to run with the newer control-plane taint. 

# Changes

* Add `node-role.kubernetes.io/control-plane` toleration to  system-upgrade-controller manifests.
* Bump system-upgrade-controller to v0.7.5.

# Testing

Tested manifest changes in k3os kubernetes clusters -- system-upgrade-controller runs correctly in clusters with `node-role.kubernetes.io/control-plane=true:NoSchedule` taint on controller nodes. Also tested v0.7.5 deploys and starts up correctly.