### PR TITLE
[backport v0.19.x] base: add libc6-compat and gcompat

### DIFF
--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -19,6 +19,7 @@ RUN apk --no-cache add \
     efibootmgr \
     eudev \
     findutils \
+    gcompat \
     grub-efi \
     haveged \
     htop \
@@ -30,6 +31,7 @@ RUN apk --no-cache add \
     jq \
     kbd-bkeymaps \
     lm-sensors \
+    libc6-compat \
     logrotate \
     lsscsi \
     lvm2 \


### PR DESCRIPTION
Enables running (some) binaries compiled against glibc.

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
(cherry picked from commit 892e3168962cd8b3b7fc40e0dab7195e084545c3)
