### PR TITLE
suc: v0.8.0

### DIFF
--- a/overlay/share/rancher/k3s/server/manifests/system-upgrade-controller.yaml
+++ b/overlay/share/rancher/k3s/server/manifests/system-upgrade-controller.yaml
@@ -54,10 +54,15 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - {key: "node-role.kubernetes.io/master", operator: In, values: ["true"]}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - { key: node-role.kubernetes.io/control-plane, operator: Exists }
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - { key: node-role.kubernetes.io/master, operator: Exists }
       serviceAccountName: k3os-upgrade
       tolerations:
         - key: "CriticalAddonsOnly"
@@ -70,7 +75,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: system-upgrade-controller
-          image: rancher/system-upgrade-controller:v0.7.7-rc.1
+          image: rancher/system-upgrade-controller:v0.8.0
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:


### PR DESCRIPTION
- rancher/system-upgrade-controller:v0.8.0
- adjust the manifest to prefer scheduling to master/control-plane
  instead of requiring it.

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
