### PR TITLE
[release v0.21.x] suc: v0.7.7

### DIFF
--- a/overlay/share/rancher/k3s/server/manifests/system-upgrade-controller.yaml
+++ b/overlay/share/rancher/k3s/server/manifests/system-upgrade-controller.yaml
@@ -54,10 +54,15 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - {key: "node-role.kubernetes.io/master", operator: In, values: ["true"]}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - { key: node-role.kubernetes.io/control-plane, operator: Exists }
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - { key: node-role.kubernetes.io/master, operator: Exists }
       serviceAccountName: k3os-upgrade
       tolerations:
         - key: "CriticalAddonsOnly"
@@ -70,7 +75,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: system-upgrade-controller
-          image: rancher/system-upgrade-controller:v0.7.7-rc.1
+          image: rancher/system-upgrade-controller:v0.7.7
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/overlay/share/rancher/k3s/server/manifests/system-upgrade-plans/k3os-latest.yaml
+++ b/overlay/share/rancher/k3s/server/manifests/system-upgrade-plans/k3os-latest.yaml
@@ -22,8 +22,7 @@ spec:
     matchExpressions:
       # This limits application of this upgrade only to nodes that have opted in by applying this label.
       # Additionally, a value of `disabled` for this label on a node will cause the controller to skip over the node.
-      - {key: k3os.io/upgrade, operator: Exists}
-      - {key: k3os.io/upgrade, operator: NotIn, values: ["disabled"]}
+      - {key: k3os.io/upgrade, operator: In, values: ["latest"]}
       # This label is set by k3OS, therefore a node without it should not apply this upgrade.
       - {key: k3os.io/mode, operator: Exists}
       # Additionally, do not attempt to upgrade nodes booted from "live" CDROM.


### PR DESCRIPTION
    - rancher/system-upgrade-controller:v0.7.7
    - adjust the manifest to prefer scheduling to master/control-plane
      instead of requiring it.

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
(cherry picked from commit 083500ab67bec3fd482f7a7d2aa89578c2f1f289)
