### PR TITLE
Added cryptsetup to base

### DIFF
--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -60,6 +60,7 @@ RUN apk --no-cache add \
     tzdata \
     util-linux \
     vim \
+    cryptsetup \
     wireguard-tools \
     wpa_supplicant \
     xfsprogs \


### PR DESCRIPTION
With [Longhorn v1.2.0](https://github.com/longhorn/longhorn/releases/tag/v1.2.0) the encryption for volumes was added.

This is according to their [documentation](https://longhorn.io/docs/1.2.0/advanced-resources/volume-encryption/#requirements) based on `cryptsetup`

This patch adds the missing cryptsetup to k3os