### PR TITLE
Support for silent installation with a default device

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ Below is a reference of all cmdline args used to automate installation
 |:------------------------|---------|---------------------------------------------------|---------------------------------|
 | k3os.mode               |         | install                                           | Boot k3OS to the installer, not an interactive session |
 | k3os.fallback_mode      |         | install                                           | If a valid K3OS_STATE partition is not found to boot from, run the installation |
-| k3os.install.silent     | false   | true                                              | Ensure no questions will be asked |
+| k3os.install.silent     | false   | true                                              | Ensure no questions will be asked. <br/> :warning: When ```true``` and ```k3os.install.device``` **not** provided set to the first one available (e.g /dev/sda). |
 | k3os.install.force_efi  | false   | true                                              | Force EFI installation even when EFI is not detected |
-| k3os.install.device     |         | /dev/vda                                          | Device to partition and format (/dev/sda, /dev/vda) |
+| k3os.install.device     |         | /dev/vda                                          | Device to partition and format (/dev/sda, /dev/vda). <br/> :warning: When ```k3os.install.silent=true``` and *device* **not** provided set to the first one available (e.g /dev/sda). |
 | k3os.install.config_url |         | [https://gist.github.com/.../dweomer.yaml](https://gist.github.com/dweomer/8750d56fb21a3fbc8d888609d6e74296#file-dweomer-yaml) | The URL of the config to be installed at `/k3os/system/config.yaml` |
-| k3os.install.iso_url    |         | https://github.com/rancher/k3os/../k3os-amd64.iso | ISO to download and install from if booting from kernel/vmlinuz and not ISO. |
+| k3os.install.iso_url    |         | https://github.com/rancher/k3os/../k3os-amd64.iso | ISO to download and install from if booting from kernel/vmlinuz and not ISO |
 | k3os.install.no_format  |         | true                                              | Do not partition and format, assume layout exists already |
 | k3os.install.tty        | auto    | ttyS0                                             | The tty device used for console |
 | k3os.install.debug      | false   | true                                              | Run installation with more logging and configure debug for installed system |

--- a/pkg/cliinstall/ask.go
+++ b/pkg/cliinstall/ask.go
@@ -88,17 +88,16 @@ func AskInstallDevice(cfg *config.CloudConfig) error {
 		return nil
 	}
 
-	output, err := exec.Command("/bin/sh", "-c", "lsblk -r -o NAME,TYPE | grep -w disk | awk '{print $1}'").CombinedOutput()
+	disks, err := util.AvailableDisks()
 	if err != nil {
 		return err
 	}
-	fields := strings.Fields(string(output))
-	i, err := questions.PromptFormattedOptions("Installation target. Device will be formatted", -1, fields...)
+	i, err := questions.PromptFormattedOptions("Installation target. Device will be formatted", -1, disks...)
 	if err != nil {
 		return err
 	}
 
-	cfg.K3OS.Install.Device = "/dev/" + fields[i]
+	cfg.K3OS.Install.Device = "/dev/" + disks[i]
 	return nil
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 )
 
 func WriteFileAtomic(filename string, data []byte, perm os.FileMode) error {
@@ -110,4 +111,14 @@ func EnsureDirectoryExists(dir string) error {
 		}
 	}
 	return nil
+}
+
+// AvailableDisks finds and returns an array of all available disk(s) in the current environment.
+// It returns an array of available disk(s) and any error encountered.
+func AvailableDisks() ([]string, error) {
+	output, err := exec.Command("/bin/sh", "-c", "lsblk -r -o NAME,TYPE | grep -w disk | awk '{print $1}'").CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+	return strings.Fields(string(output)), nil
 }


### PR DESCRIPTION
This pull request aims to fix the following issues:
#807 #205

Currently, if the installation is silent with ```k3os.install.silent=true``` you are *forced* to also set ```k3os.install.device```.
This behavior is not documented in the current README.

I think that setting only ```k3os.install.silent=true``` without a *device* could be very useful (not only for my case).
The *device* is set to the first one available, simple as that.

Of course, setting both ```silent``` with a specific ```device``` is still supported.