### PR TITLE
Retain additional files needed by update-ca-certificates as part of rootfs

### DIFF
--- a/images/20-rootfs/Dockerfile
+++ b/images/20-rootfs/Dockerfile
@@ -47,6 +47,7 @@ RUN rm -rf \
     /usr/src/image/etc/ssl \
  && mkdir -p /usr/src/image/etc/ssl/certs/ \
  && cp -rf /etc/ssl/certs/ca-certificates.crt /usr/src/image/etc/ssl/certs \
+ && cp /etc/ca-certificates.conf /usr/src/image/etc/ca-certificates.conf \
  && ln -s certs/ca-certificates.crt /usr/src/image/etc/ssl/cert.pem
 
 # setup /usr/local
@@ -63,7 +64,6 @@ RUN rm -rf \
     /usr/src/image/etc/hostname \
     /usr/src/image/etc/alpine-release \
     /usr/src/image/etc/apk \
-    /usr/src/image/etc/ca-certificates* \
     /usr/src/image/etc/os-release \
  && ln -s /usr/lib/os-release /usr/src/image/etc/os-release
 


### PR DESCRIPTION
As mentioned in #518, the `update-ca-certificates` command on k3os doesn't work the way people expect; when running `update-ca-certificates`, all of the default certificates are lost and only user certificates are included in the final ca-certificates bundle. There have been workarounds proposed such as copying the default ca-certificates bundle from `/etc/ssl/certs` into `/usr/local/share/ca-certificates` and then appending the additional CA certificates to that file before running `update-ca-certificates`.

The _intended_ behavior for `update-ca-certificates` is that it pulls user certificates from `/usr/local/share/ca-certificates`, and system default certificates from `/usr/share/ca-certificates`; however, `update-ca-certificates` does not automatically bundle _all_ certificates found in `/usr/share/ca-certificates` - instead, it only bundles those system-default certificates listed in the configuration file `/etc/ca-certificates.conf`. 

The reason for the misbehavior of `update-ca-certificates` on k3os, then, is the lack of a `/etc/ca-certificates.conf` file. This file is part of the `ca-certificates` package in alpine (the same package that contains the `update-ca-certificates` command), however the k3os build process doesn't include this file by default when building the rootfs. This PR addresses that issue, ensuring that the rootfs includes all of the files needed for `update-ca-certificates` to operate as intended.