### PR TITLE
Updated parted args to correctly grow the partition to 100%

### DIFF
--- a/overlay/libexec/k3os/boot
+++ b/overlay/libexec/k3os/boot
@@ -167,7 +167,7 @@ setup_state_dirs()
 
 do_grow_live()
 {
-    parted $1 resizepart $2 yes 100%
+    echo -e "Yes" | parted $1 unit % resizepart $2 100% ---pretend-input-tty
     partprobe $1
     sleep 2
     resize2fs $3


### PR DESCRIPTION
The parted command wasn't resizing the root partition to use the available disk space.  The issue in parted is also documented in the bug report https://bugs.launchpad.net/ubuntu/+source/parted/+bug/1270203. 

In this PR the invocation of the `parted` command has been updated so that the partition is properly resized to used the available disk space.

This works for parted 3.4 which is what's present in the current pre-release version (`v0.22.2-k3s2r0`) of k3os. In the release version (`v0.21.5-k3s2r1`) however the parted version is 3.3 and requires a slight modification in the command:

```bash
echo -e "Yes\n100%" | sudo parted $1 resizepart $2 ---pretend-input-tty unit %
```

In case there are further maintenance releases planned for the `v0.21.5` series when maybe we should update the line to 

```bash
echo -e "Yes" | parted $1 unit % resizepart $2 100% ---pretend-input-tty || echo -e "Yes\n100%" | parted $1 resizepart $2 ---pretend-input-tty unit %
```