### PR TITLE
Allow explicit set of ISO_DEVICE env variable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -227,7 +227,14 @@ EOF
 
 get_iso()
 {
-    ISO_DEVICE=$(blkid -L K3OS || true)
+
+    ### When booting install media from USB, there is a chance that the K3OS label
+    ### will detect the proper partition.  For that reason, we allow the admin
+    ### to explicitly set the ISO_DEVICE variable before invoking install
+    if [ -z "${ISO_DEVICE}" ]; then
+        ISO_DEVICE=$(blkid -L K3OS || true)
+    fi
+
     if [ -z "${ISO_DEVICE}" ]; then
         for i in $(lsblk -o NAME,TYPE -n | grep -w disk | awk '{print $1}'); do
             mkdir -p ${DISTRO}


### PR DESCRIPTION
We found that when writing the ISO to a usb device, sometimes the `ISO_DEVICE` detection does not find the proper partition as seen below -- notice that the `K3OS` label is at both the entire disk level as well as the individual (correct) partition, yet `blkid` returns `/dev/sd2` (incorrect):

```
barney [~]# fdisk -l /dev/sdk
GPT PMBR size mismatch (19735811 != 61472767) will be corrected by write.
The backup GPT table is not on the end of the device.
Disk /dev/sdk: 29.31 GiB, 31474057216 bytes, 61472768 sectors
Disk model: DataTraveler 3.0
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: gpt
Disk identifier: 457E92A0-ECFC-4B72-B7CE-38B7AAA67341

Device        Start      End  Sectors  Size Type
/dev/sdk1        64      343      280  140K Microsoft basic data
/dev/sdk2       344     6103     5760  2.8M EFI System
/dev/sdk3      6104 19735163 19729060  9.4G Apple HFS/HFS+
/dev/sdk4  19735164 19735763      600  300K Microsoft basic data

barney [~]# lsblk -o name,label /dev/sdk
NAME   LABEL
sdk    K3OS
├─sdk1
├─sdk2
├─sdk3 K3OS
└─sdk4

barney [~]# blkid -L K3OS
/dev/sdk2
```

To work around these situations, we propose that you use the `ISO_DEVICE` environment variable directly if it's already set.

For reference, this may be due to this issue:

https://github.com/systemd/systemd/issues/14408