### PR TITLE
Support multipath-boot

### DIFF
--- a/images/00-base/Dockerfile
+++ b/images/00-base/Dockerfile
@@ -71,3 +71,5 @@ RUN apk --no-cache add \
 # replicate the default "no idea, friend" behavior of virt-what
  && touch /usr/sbin/virt-what \
  && chmod +x /usr/sbin/virt-what
+
+COPY multipath.conf /etc/multipath.conf

--- a/images/00-base/multipath.conf
+++ b/images/00-base/multipath.conf
@@ -1,0 +1,13 @@
+defaults {
+  find_multipaths "yes"
+  user_friendly_names "yes"
+}
+blacklist_exceptions {
+   property "(SCSI_IDENT_|ID_WWN)"
+}
+blacklist {
+    device {
+        vendor "VMware"
+        product "Virtual disk"
+    }
+}

--- a/images/10-kernel-stage1/Dockerfile
+++ b/images/10-kernel-stage1/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get --assume-yes update \
     lz4 \
     rsync \
     xz-utils \
+    multipath-tools-boot \
  && echo 'r8152' >> /etc/initramfs-tools/modules \
  && echo 'hfs' >> /etc/initramfs-tools/modules \
  && echo 'hfsplus' >> /etc/initramfs-tools/modules \

--- a/overlay/libexec/k3os/boot
+++ b/overlay/libexec/k3os/boot
@@ -44,6 +44,12 @@ setup_services()
         ln -s /etc/init.d/$i /etc/runlevels/sysinit
     done
 
+    if [ "$K3OS_MODE" = "local" ]; then
+      for i in udev-trigger multipath multipathd; do
+        ln -s /etc/init.d/$i /etc/runlevels/sysinit
+      done
+    fi
+
     for i in acpid hwclock syslog bootmisc hostname sysctl modules connman dbus haveged issue; do
         ln -s /etc/init.d/$i /etc/runlevels/boot
     done

--- a/overlay/libexec/k3os/mode-disk
+++ b/overlay/libexec/k3os/mode-disk
@@ -146,6 +146,22 @@ takeover()
     fi
 }
 
+### For boot from SAN, we need to ensure that the multipath devices are setup
+### while termporarily in mode=disk so that the mount & pivot_root for mode=local
+### will be the proper multipath device (rather than a single path)
+setup_multipath()
+{
+  modprobe dm-multipath
+  udevd -d
+  udevadm settle
+  udevadm trigger --type=devices --action=add
+  udevadm settle
+  multipath -v3
+  udevadm settle
+  udevadm control --exit
+}
+
+setup_multipath
 setup_mounts
 setup_k3os
 setup_kernel_squashfs


### PR DESCRIPTION
We have built a software appliance based upon k3os, and have use-cases where the installation requires boot-from-SAN (i.e., multipath support).  These changes are the basis for how we have met these requirements.  For installation, we boot into the live installer without multipath enabled and install to any one of the available paths.  Upon reboot into the installed system, we enable multipath while in `MODE=disk` before `pivot_root` and calling `init` with `MODE=local`.  The end result is such that our root fs is mounted on the multipath device / partition as seen below:

```
Filesystem                    Size  Used Avail Use% Mounted on
/dev/mapper/mpatha-part1      4.6G  1.1G  3.3G  25% /
```

Since not everyone would want this built in, maybe we could/should make these changes optional based on some build-time paramater(s).