### PR TITLE
Fix comment around use of existing ISO_DEVICE

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -229,7 +229,7 @@ get_iso()
 {
 
     ### When booting install media from USB, there is a chance that the K3OS label
-    ### will detect the proper partition.  For that reason, we allow the admin
+    ### will detect the wrong partition.  For that reason, we allow the admin
     ### to explicitly set the ISO_DEVICE variable before invoking install
     if [ -z "${ISO_DEVICE}" ]; then
         ISO_DEVICE=$(blkid -L K3OS || true)


### PR DESCRIPTION
The comment is misleading and should reference detecting the "wrong" partition instead of the "proper" partition, which is the whole reason for using ISO_DEVICE if it's already set.